### PR TITLE
Simulates random delays and data changes in SyncManager

### DIFF
--- a/src/main/java/address/MainApp.java
+++ b/src/main/java/address/MainApp.java
@@ -33,7 +33,7 @@ public class MainApp extends Application {
         storageManager.setModel(modelManager);
         mainController = new MainController(modelManager, config);
         syncManager = new SyncManager();
-        syncManager.startSyncingData(config.updateInterval);
+        syncManager.startSyncingData(config.updateInterval, config.isSimulateRandomChanges);
     }
 
     protected Config getConfig() {

--- a/src/main/java/address/model/ModelManager.java
+++ b/src/main/java/address/model/ModelManager.java
@@ -7,6 +7,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -63,11 +64,24 @@ public class ModelManager {
 
         //TODO: change to use streams instead
         for(Person p: newData){
-            if(!personData.contains(p)){
+            Optional<Person> storedPerson = getPerson(p);
+            if (storedPerson.isPresent()){
+                storedPerson.get().updateWith(p);
+            } else {
                 personData.add(p);
                 System.out.println("New data added " + p);
             }
         }
+    }
+
+    private Optional<Person> getPerson(Person person) {
+        for (Person p : personData) {
+            if (p.equals(person)) {
+                return Optional.of(p);
+            }
+        }
+
+        return Optional.empty();
     }
 
     @Subscribe

--- a/src/main/java/address/model/Person.java
+++ b/src/main/java/address/model/Person.java
@@ -131,6 +131,15 @@ public class Person {
         return birthday;
     }
 
+    public void updateWith(Person updatedData) {
+        assert this.equals(updatedData);
+
+        this.setStreet(updatedData.getStreet());
+        this.setPostalCode(updatedData.getPostalCode());
+        this.setCity(updatedData.getCity());
+        this.setBirthday(updatedData.getBirthday());
+    }
+
     @Override
     public boolean equals(Object otherPerson){
         if (otherPerson == null) {

--- a/src/main/java/address/model/Person.java
+++ b/src/main/java/address/model/Person.java
@@ -1,17 +1,10 @@
 package address.model;
 
-import java.time.LocalDate;
-
-import javafx.beans.property.IntegerProperty;
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.SimpleIntegerProperty;
-import javafx.beans.property.SimpleObjectProperty;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
+import address.util.LocalDateAdapter;
+import javafx.beans.property.*;
 
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
-import address.util.LocalDateAdapter;
+import java.time.LocalDate;
 
 /**
  * Model class for a Person.
@@ -48,7 +41,21 @@ public class Person {
         this.street = new SimpleStringProperty("some street");
         this.postalCode = new SimpleIntegerProperty(1234);
         this.city = new SimpleStringProperty("some city");
-        this.birthday = new SimpleObjectProperty<LocalDate>(LocalDate.of(1999, 2, 21));
+        this.birthday = new SimpleObjectProperty<>(LocalDate.of(1999, 2, 21));
+    }
+
+    /**
+     * Copy constructor
+     * @param person
+     */
+    public Person(Person person) {
+        this.firstName = new SimpleStringProperty(person.getFirstName());
+        this.lastName = new SimpleStringProperty(person.getLastName());
+
+        this.street = new SimpleStringProperty(person.getStreet());
+        this.postalCode = new SimpleIntegerProperty(person.getPostalCode());
+        this.city = new SimpleStringProperty(person.getCity());
+        this.birthday = new SimpleObjectProperty<>(person.getBirthday());
     }
 
     public String getFirstName() {

--- a/src/main/java/address/sync/CloudSimulator.java
+++ b/src/main/java/address/sync/CloudSimulator.java
@@ -1,0 +1,7 @@
+package address.sync;
+
+/**
+ * Created by ndt on 9/5/16.
+ */
+public class CloudSimulator {
+}

--- a/src/main/java/address/sync/CloudSimulator.java
+++ b/src/main/java/address/sync/CloudSimulator.java
@@ -16,9 +16,9 @@ public class CloudSimulator {
     private int MIN_DELAY_IN_SEC = 1;
     private int DELAY_RANGE = 5;
 
-    private double MODIFY_PERSON_PROBABILITY = 0.3;
+    private double MODIFY_PERSON_PROBABILITY = 0.1;
     private double ADD_PERSON_PROBABILITY = 0.05;
-    private int MAX_NUM_PERSONS_TO_ADD = 3;
+    private int MAX_NUM_PERSONS_TO_ADD = 2;
 
     private Random random = new Random();
     private final File file;
@@ -34,40 +34,55 @@ public class CloudSimulator {
      * When failure condition occurs, this returns an empty data set.
      */
     public List<Person> getSimulatedCloudData() {
+        System.out.print("Simulating cloud data retrieval...");
+
         if (random.nextDouble() <= FAILURE_PROBABILITY) {
-            System.out.println("Cloud simulator: failure occured!");
+            System.out.println("Cloud simulator: failure occurred!");
             return new ArrayList<>();
         }
 
         List<Person> modifiedData = new ArrayList<>();
         try {
             List<Person> data = XmlHelper.getDataFromFile(this.file);
-
-            for (Person person : data) {
-                if (random.nextDouble() <= MODIFY_PERSON_PROBABILITY) {
-                    System.out.println("Cloud simulator: modifying " + person);
-                    person.setCity(java.util.UUID.randomUUID().toString());
-                    person.setStreet(java.util.UUID.randomUUID().toString());
-                    person.setPostalCode(random.nextInt(999999));
-                }
-                modifiedData.add(person);
-            }
-            for (int i = 0; i < MAX_NUM_PERSONS_TO_ADD; i++) {
-                if (random.nextDouble() <= ADD_PERSON_PROBABILITY) {
-                    Person person = new Person(java.util.UUID.randomUUID().toString(),
-                                               java.util.UUID.randomUUID().toString());
-                    System.out.println("Cloud simulator: adding " + person);
-                    modifiedData.add(person);
-                }
-            }
+            modifiedData = simulateDataModification(data);
+            modifiedData.addAll(simulateDataAddition());
             XmlHelper.saveToFile(this.file, modifiedData);
-
             TimeUnit.SECONDS.sleep(random.nextInt(DELAY_RANGE) + MIN_DELAY_IN_SEC);
-
         } catch (JAXBException e) {
             System.out.println("File not found or is not in valid xml format : " + file);
         } catch (InterruptedException e) {
             e.printStackTrace();
+        }
+
+        return modifiedData;
+    }
+
+    private List<Person> simulateDataAddition() {
+        List<Person> newData = new ArrayList<>();
+
+        for (int i = 0; i < MAX_NUM_PERSONS_TO_ADD; i++) {
+            if (random.nextDouble() <= ADD_PERSON_PROBABILITY) {
+                Person person = new Person(java.util.UUID.randomUUID().toString(),
+                                           java.util.UUID.randomUUID().toString());
+                System.out.println("Cloud simulator: adding " + person);
+                newData.add(person);
+            }
+        }
+
+        return newData;
+    }
+
+    private List<Person> simulateDataModification(List<Person> data) {
+        List<Person> modifiedData = new ArrayList<>();
+
+        for (Person person : data) {
+            if (random.nextDouble() <= MODIFY_PERSON_PROBABILITY) {
+                System.out.println("Cloud simulator: modifying " + person);
+                person.setCity(java.util.UUID.randomUUID().toString());
+                person.setStreet(java.util.UUID.randomUUID().toString());
+                person.setPostalCode(random.nextInt(999999));
+            }
+            modifiedData.add(person);
         }
 
         return modifiedData;

--- a/src/main/java/address/sync/CloudSimulator.java
+++ b/src/main/java/address/sync/CloudSimulator.java
@@ -1,7 +1,75 @@
 package address.sync;
 
-/**
- * Created by ndt on 9/5/16.
- */
+import address.model.Person;
+import address.util.XmlHelper;
+
+import javax.xml.bind.JAXBException;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
 public class CloudSimulator {
+    private double FAILURE_PROBABILITY = 0.1;
+
+    private int MIN_DELAY_IN_SEC = 1;
+    private int DELAY_RANGE = 5;
+
+    private double MODIFY_PERSON_PROBABILITY = 0.3;
+    private double ADD_PERSON_PROBABILITY = 0.05;
+    private int MAX_NUM_PERSONS_TO_ADD = 3;
+
+    private Random random = new Random();
+    private final File file;
+
+    public CloudSimulator(File file) {
+        this.file = file;
+    }
+
+    /**
+     * Gets the updated data subjected to simulated random behaviors such as random changes,
+     * random delays and random failures. The data is originally obtained from a given file.
+     * The data is possibly modified in each call to this method and is persisted onto the same file.
+     * When failure condition occurs, this returns an empty data set.
+     */
+    public List<Person> getSimulatedCloudData() {
+        if (random.nextDouble() <= FAILURE_PROBABILITY) {
+            System.out.println("Cloud simulator: failure occured!");
+            return new ArrayList<>();
+        }
+
+        List<Person> modifiedData = new ArrayList<>();
+        try {
+            List<Person> data = XmlHelper.getDataFromFile(this.file);
+
+            for (Person person : data) {
+                if (random.nextDouble() <= MODIFY_PERSON_PROBABILITY) {
+                    System.out.println("Cloud simulator: modifying " + person);
+                    person.setCity(java.util.UUID.randomUUID().toString());
+                    person.setStreet(java.util.UUID.randomUUID().toString());
+                    person.setPostalCode(random.nextInt(999999));
+                }
+                modifiedData.add(person);
+            }
+            for (int i = 0; i < MAX_NUM_PERSONS_TO_ADD; i++) {
+                if (random.nextDouble() <= ADD_PERSON_PROBABILITY) {
+                    Person person = new Person(java.util.UUID.randomUUID().toString(),
+                                               java.util.UUID.randomUUID().toString());
+                    System.out.println("Cloud simulator: adding " + person);
+                    modifiedData.add(person);
+                }
+            }
+            XmlHelper.saveToFile(this.file, modifiedData);
+
+            TimeUnit.SECONDS.sleep(random.nextInt(DELAY_RANGE) + MIN_DELAY_IN_SEC);
+
+        } catch (JAXBException e) {
+            System.out.println("File not found or is not in valid xml format : " + file);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        return modifiedData;
+    }
 }

--- a/src/main/java/address/sync/SyncManager.java
+++ b/src/main/java/address/sync/SyncManager.java
@@ -5,9 +5,7 @@ import address.events.EventManager;
 import address.events.NewMirrorDataEvent;
 import address.model.Person;
 import address.preferences.PreferencesManager;
-import address.util.XmlHelper;
 
-import javax.xml.bind.JAXBException;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
@@ -56,14 +54,8 @@ public class SyncManager {
 
     private List<Person> getMirrorData() {
         System.out.println("Updating data: " + System.nanoTime());
-        File mirrorFile = null;
-        List<Person> mirrorData = Collections.emptyList();
-        try {
-            mirrorFile = new File(PreferencesManager.getInstance().getPersonFilePath().toString() + "-mirror.xml");
-            mirrorData = XmlHelper.getDataFromFile(mirrorFile);
-        } catch (JAXBException e) {
-            System.out.println("File not found or is not in valid xml format : " + mirrorFile);
-        }
-        return mirrorData;
+        File mirrorFile = new File(PreferencesManager.getInstance().getPersonFilePath().toString() + "-mirror.xml");
+        CloudSimulator simulator = new CloudSimulator(mirrorFile);
+        return simulator.getSimulatedCloudData();
     }
 }

--- a/src/main/java/address/sync/SyncManager.java
+++ b/src/main/java/address/sync/SyncManager.java
@@ -24,8 +24,11 @@ public class SyncManager {
 
     private List<Person> previousList = Collections.emptyList();
 
-    public void startSyncingData(long interval){
+    private boolean isSimulatedRandomChanges = false;
+
+    public void startSyncingData(long interval, boolean isSimulateRandomChanges) {
         if(interval > 0) {
+            this.isSimulatedRandomChanges = isSimulateRandomChanges;
             updatePeriodically(interval);
         }
     }
@@ -55,7 +58,7 @@ public class SyncManager {
     private List<Person> getMirrorData() {
         System.out.println("Updating data: " + System.nanoTime());
         File mirrorFile = new File(PreferencesManager.getInstance().getPersonFilePath().toString() + "-mirror.xml");
-        CloudSimulator simulator = new CloudSimulator(mirrorFile);
-        return simulator.getSimulatedCloudData();
+        CloudSimulator cloudSimulator = new CloudSimulator(this.isSimulatedRandomChanges);
+        return cloudSimulator.getSimulatedCloudData(mirrorFile);
     }
 }

--- a/src/main/java/address/util/Config.java
+++ b/src/main/java/address/util/Config.java
@@ -6,4 +6,5 @@ package address.util;
 public class Config {
     public String appTitle = "Address App";
     public long updateInterval = 5;
+    public boolean isSimulateRandomChanges = false;
 }


### PR DESCRIPTION
Fixes #1 

When SyncManager is called to get new data, random modifications and additions of data are performed on the mirror data set. Random delay and failure (empty results) is also simulated.

Random changes are disabled by default. It can be turned on by setting `isRandomChangesEnabled` in `Config`