### PR TITLE
SyncManager does not request data to be changed on the cloud side #13

### DIFF
--- a/src/main/java/address/events/LocalModelSyncedEvent.java
+++ b/src/main/java/address/events/LocalModelSyncedEvent.java
@@ -1,0 +1,15 @@
+package address.events;
+
+import address.model.Person;
+
+import java.util.List;
+
+/** Indicates person data in the model was synced with data on the cloud */
+public class LocalModelSyncedEvent {
+
+    public List<Person> personData;
+
+    public LocalModelSyncedEvent(List<Person> personData){
+        this.personData = personData;
+    }
+}

--- a/src/main/java/address/model/ModelManager.java
+++ b/src/main/java/address/model/ModelManager.java
@@ -3,6 +3,7 @@ package address.model;
 import address.events.EventManager;
 import address.events.LocalModelChangedEvent;
 import address.events.FilterCommittedEvent;
+import address.events.LocalModelSyncedEvent;
 import address.events.NewMirrorDataEvent;
 import address.events.*;
 
@@ -87,12 +88,14 @@ public class ModelManager {
         for(Person p: newData){
             Optional<Person> storedPerson = getPerson(p);
             if (storedPerson.isPresent()){
-                updatePerson(storedPerson.get(), p);
+                storedPerson.get().update(p);
             } else {
                 personData.add(p);
                 System.out.println("New data added " + p);
             }
         }
+
+        EventManager.getInstance().post(new LocalModelSyncedEvent(personData));
     }
 
     private Optional<Person> getPerson(Person person) {

--- a/src/main/java/address/storage/StorageManager.java
+++ b/src/main/java/address/storage/StorageManager.java
@@ -6,7 +6,6 @@ import address.model.Person;
 import address.preferences.PreferencesManager;
 import address.util.XmlHelper;
 import com.google.common.eventbus.Subscribe;
-import javafx.collections.ListChangeListener;
 
 import java.io.File;
 import java.util.Collections;
@@ -70,6 +69,12 @@ public class StorageManager {
     private void handleLocalModelChangedEvent(LocalModelChangedEvent lmce){
         System.out.println("Local data changed, saving to primary data file");
         savePersonDataToFile(PreferencesManager.getInstance().getPersonFilePath(), lmce.personData);
+    }
+
+    @Subscribe
+    private void handleLocalModelSyncedEvent(LocalModelSyncedEvent lmse){
+        System.out.println("Local data synced, saving to primary data file");
+        savePersonDataToFile(PreferencesManager.getInstance().getPersonFilePath(), lmse.personData);
     }
 
     @Subscribe

--- a/src/main/java/address/sync/CloudSimulator.java
+++ b/src/main/java/address/sync/CloudSimulator.java
@@ -59,6 +59,15 @@ public class CloudSimulator {
         return modifiedData;
     }
 
+    /**
+     * Requests the simulated cloud to update its data with the given data. This data should be
+     * written to the provided mirror file
+     * @param delay Duration of delay in seconds to be simulated before the request is completed
+     */
+    public void requestChangesToCloud(File file, List<Person> data, int delay) throws JAXBException {
+        XmlHelper.saveToFile(file, data);
+    }
+
     private List<Person> simulateDataAddition() {
         List<Person> newData = new ArrayList<>();
 

--- a/src/main/java/address/sync/CloudSimulator.java
+++ b/src/main/java/address/sync/CloudSimulator.java
@@ -65,7 +65,13 @@ public class CloudSimulator {
      * @param delay Duration of delay in seconds to be simulated before the request is completed
      */
     public void requestChangesToCloud(File file, List<Person> data, int delay) throws JAXBException {
-        XmlHelper.saveToFile(file, data);
+        try {
+            TimeUnit.SECONDS.sleep(delay);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        } finally {
+            XmlHelper.saveToFile(file, data);
+        }
     }
 
     private List<Person> simulateDataAddition() {

--- a/src/main/java/address/sync/SyncManager.java
+++ b/src/main/java/address/sync/SyncManager.java
@@ -75,7 +75,7 @@ public class SyncManager {
         File mirrorFile = new File(PreferencesManager.getInstance().getPersonFilePath().toString() + "-mirror.xml");
         CloudSimulator cloudSimulator = new CloudSimulator(this.isSimulatedRandomChanges);
         try {
-            cloudSimulator.requestChangesToCloud(mirrorFile, lmce.personData, 3);
+            cloudSimulator.requestChangesToCloud(mirrorFile, lmce.personData, 2);
         } catch (JAXBException e) {
             System.out.println("Error requesting changes to the cloud");
         }

--- a/src/main/resources/view/PersonEditDialog.fxml
+++ b/src/main/resources/view/PersonEditDialog.fxml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.control.*?>
-<?import java.lang.*?>
 <?import javafx.scene.layout.*?>
-<?import javafx.scene.layout.AnchorPane?>
 
 <?import java.net.URL?>
 <AnchorPane prefHeight="354.0" prefWidth="439.0" styleClass="background" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1" fx:controller="address.controller.PersonEditDialogController">


### PR DESCRIPTION
Fixes #13 

Simple write to cloud in which all data given to the `SyncManager` will override existing data on the mirror file.