### PR TITLE
UI does not reflect changes coming from SyncManager immediately #12

### DIFF
--- a/src/main/java/address/controller/PersonOverviewController.java
+++ b/src/main/java/address/controller/PersonOverviewController.java
@@ -12,7 +12,6 @@ import javafx.scene.control.Label;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import address.model.Person;
-import address.util.DateUtil;
 import javafx.scene.control.TextField;
 
 public class PersonOverviewController {
@@ -80,12 +79,12 @@ public class PersonOverviewController {
     private void showPersonDetails(Person person) {
         if (person != null) {
             // Fill the labels with info from the person object.
-            firstNameLabel.setText(person.getFirstName());
-            lastNameLabel.setText(person.getLastName());
-            streetLabel.setText(person.getStreet());
-            postalCodeLabel.setText(Integer.toString(person.getPostalCode()));
-            cityLabel.setText(person.getCity());
-            birthdayLabel.setText(DateUtil.format(person.getBirthday()));
+            firstNameLabel.textProperty().bind(person.firstNameProperty());
+            lastNameLabel.textProperty().bind(person.lastNameProperty());
+            streetLabel.textProperty().bind(person.streetProperty());
+            postalCodeLabel.textProperty().bind(person.postalCodeProperty().asString());
+            cityLabel.textProperty().bind(person.cityProperty());
+            birthdayLabel.textProperty().bind(person.birthdayProperty().asString());
         } else {
             // Person is null, remove all the text.
             firstNameLabel.setText("");
@@ -94,6 +93,12 @@ public class PersonOverviewController {
             postalCodeLabel.setText("");
             cityLabel.setText("");
             birthdayLabel.setText("");
+            firstNameLabel.textProperty().unbind();
+            lastNameLabel.textProperty().unbind();
+            streetLabel.textProperty().unbind();
+            postalCodeLabel.textProperty().unbind();
+            cityLabel.textProperty().unbind();
+            birthdayLabel.textProperty().unbind();
         }
     }
     

--- a/src/main/java/address/model/ModelManager.java
+++ b/src/main/java/address/model/ModelManager.java
@@ -13,6 +13,7 @@ import address.parser.Parser;
 import address.parser.expr.Expr;
 import address.parser.expr.PredExpr;
 import address.parser.qualifier.TrueQualifier;
+import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
@@ -113,7 +114,7 @@ public class ModelManager {
      * @param updated The temporary Person object containing new values.
      */
     public void updatePerson(Person original, Person updated){
-        original.update(updated);
+        Platform.runLater(() -> original.update(updated));
         EventManager.getInstance().post(new LocalModelChangedEvent(personData));
     }
 


### PR DESCRIPTION
Fixes #12 (ongoing)

Since we modify UI information, we have to wrap the `Person` update in `Platform.runLater` to perform updates on the UI thread. I'm sure there's a better way to specify the flow; will refactor later.