### PR TITLE
Support contact groups/labels #9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 build/
 .gradle/
+*.iml

--- a/src/main/java/address/MainApp.java
+++ b/src/main/java/address/MainApp.java
@@ -1,6 +1,7 @@
 package address;
 
 import address.controller.MainController;
+import address.model.AddressBookWrapper;
 import address.model.ModelManager;
 import address.preferences.PreferencesManager;
 import address.storage.StorageManager;
@@ -28,7 +29,8 @@ public class MainApp extends Application {
     protected void setupComponents() {
         config = getConfig();
         preferencesManager = PreferencesManager.getInstance();
-        modelManager = new ModelManager(StorageManager.getPersonDataFromFile(preferencesManager.getPersonFilePath()));
+        AddressBookWrapper dataFromFile = StorageManager.getDataFromFile(preferencesManager.getPersonFilePath());
+        modelManager = new ModelManager(dataFromFile.getPersons(), dataFromFile.getGroups());
         storageManager = new StorageManager(modelManager);
         mainController = new MainController(modelManager, config);
         syncManager = new SyncManager();

--- a/src/main/java/address/controller/MainController.java
+++ b/src/main/java/address/controller/MainController.java
@@ -131,6 +131,7 @@ public class MainController {
             personEditDialogController.setDialogStage(dialogStage);
             personEditDialogController.setModelManager(modelManager);
             personEditDialogController.setPerson(person);
+            personEditDialogController.setModel(modelManager.getContactGroups(), person.getContactGroups());
 
             // Show the dialog and wait until the user closes it
             dialogStage.showAndWait();

--- a/src/main/java/address/controller/PersonEditDialogController.java
+++ b/src/main/java/address/controller/PersonEditDialogController.java
@@ -1,19 +1,172 @@
 package address.controller;
 
 import address.model.ModelManager;
+import address.events.EventManager;
+import address.events.GroupSearchResultsChangedEvent;
+import address.events.GroupsChangedEvent;
+import address.model.ContactGroup;
+import com.google.common.eventbus.Subscribe;
 import javafx.fxml.FXML;
-import javafx.scene.control.Alert;
+import javafx.scene.control.*;
 import javafx.scene.control.Alert.AlertType;
-import javafx.scene.control.TextField;
+import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import address.model.Person;
 import address.util.DateUtil;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 /**
  * Dialog to edit details of a person.
- * 
  */
 public class PersonEditDialogController {
+    public class SelectableContactGroup extends ContactGroup {
+        private boolean isSelected = false;
+
+        private SelectableContactGroup(ContactGroup contactGroup) {
+            super(contactGroup.getName());
+        }
+
+        private void setSelected(boolean isSelected) {
+            this.isSelected = isSelected;
+        }
+
+        private boolean isSelected() {
+            return this.isSelected;
+        }
+    }
+    private class PersonEditDialogModel {
+        List<SelectableContactGroup> groups = new ArrayList<>();
+        List<SelectableContactGroup> filteredGroups = new ArrayList<>();
+        Optional<Integer> selectedGroupIndex = Optional.empty();
+
+        List<SelectableContactGroup> assignedGroups = new ArrayList<>();
+
+        private PersonEditDialogModel(List<ContactGroup> groups, List<ContactGroup> assignedGroups) {
+            List<SelectableContactGroup> selectableContactGroups = groups.stream()
+                    .map(SelectableContactGroup::new)
+                    .collect(Collectors.toList());
+            this.groups.addAll(selectableContactGroups);
+
+            assignedGroups.stream()
+                    .forEach(assignedGroup -> {
+                        this.assignedGroups.addAll(this.groups.stream()
+                                .filter(group -> group.getName().equals(assignedGroup.getName()))
+                                .collect(Collectors.toList()));
+                    });
+
+            EventManager.getInstance().post(new GroupsChangedEvent(this.assignedGroups));
+            setFilter("");
+        }
+
+        private Optional<SelectableContactGroup> getSelection() {
+            return filteredGroups.stream()
+                    .filter(SelectableContactGroup::isSelected)
+                    .findFirst();
+        }
+
+        private void toggleSelection() {
+            Optional<SelectableContactGroup> selection = getSelection();
+            if (!selection.isPresent()) return;
+
+            if (assignedGroups.contains(selection.get())) {
+                assignedGroups.remove(selection.get());
+            } else {
+                assignedGroups.add(selection.get());
+            }
+
+            EventManager.getInstance().post(new GroupsChangedEvent(assignedGroups));
+        }
+
+        private void selectIndex(int index) {
+            clearSelection();
+            for (int i = 0; i < filteredGroups.size(); i++) {
+                if (i == index) {
+                    SelectableContactGroup group = filteredGroups.remove(i);
+                    group.setSelected(true);
+                    filteredGroups.add(i, group);
+                }
+            }
+        }
+
+        private void clearSelection() {
+            for (int i = 0; i < filteredGroups.size(); i++) {
+                if (filteredGroups.get(i).isSelected()) {
+                    SelectableContactGroup group = filteredGroups.remove(i);
+                    group.setSelected(false);
+                    filteredGroups.add(i, group);
+                }
+            }
+        }
+
+        private void selectNext() {
+            if (!canIncreaseIndex()) return;
+            selectedGroupIndex = Optional.of(selectedGroupIndex.orElse(-1) + 1);
+            updateSelection();
+            EventManager.getInstance().post(new GroupSearchResultsChangedEvent(filteredGroups));
+        }
+
+        private void updateSelection() {
+            if (selectedGroupIndex.isPresent()) {
+                selectIndex(selectedGroupIndex.get());
+            } else {
+                clearSelection();
+            }
+        }
+
+        private boolean canIncreaseIndex() {
+            return !filteredGroups.isEmpty() && (!selectedGroupIndex.isPresent() || selectedGroupIndex.get() < filteredGroups.size() - 1);
+        }
+
+        private void selectPrevious() {
+            if (!canDecreaseIndex()) return;
+            selectedGroupIndex = Optional.of(selectedGroupIndex.get() - 1);
+            updateSelection();
+            EventManager.getInstance().post(new GroupSearchResultsChangedEvent(filteredGroups));
+        }
+
+        private boolean canDecreaseIndex() {
+            return selectedGroupIndex.isPresent() && selectedGroupIndex.get() > 0;
+        }
+
+        private void setFilter(String filter) {
+
+            List<SelectableContactGroup> newContactGroups = groups.stream()
+                    .filter(group -> group.getName().contains(filter))
+                    .collect(Collectors.toList());
+
+            List<SelectableContactGroup> toBeAdded = newContactGroups.stream()
+                    .filter(newContactGroup -> !filteredGroups.contains(newContactGroup))
+                    .collect(Collectors.toList());
+            List<SelectableContactGroup> toBeRemoved = filteredGroups.stream()
+                    .filter(oldContactGroup -> !newContactGroups.contains(oldContactGroup))
+                    .collect(Collectors.toList());
+
+            toBeRemoved.stream()
+                    .forEach(toRemove -> filteredGroups.remove(toRemove));
+            toBeAdded.stream()
+                    .forEach(toAdd -> filteredGroups.add(toAdd));
+
+            if (!filter.isEmpty() && !filteredGroups.isEmpty()) {
+                selectedGroupIndex = Optional.of(0);
+            } else {
+                selectedGroupIndex = Optional.empty();
+            }
+
+            updateSelection();
+
+            EventManager.getInstance().post(new GroupSearchResultsChangedEvent(filteredGroups));
+        }
+
+        private List<ContactGroup> getAssignedGroups() {
+            return assignedGroups.stream()
+                    .map(assignedGroup -> new ContactGroup(assignedGroup.getName()))
+                    .collect(Collectors.toList());
+        }
+    }
 
     @FXML
     private TextField firstNameField;
@@ -27,12 +180,21 @@ public class PersonEditDialogController {
     private TextField cityField;
     @FXML
     private TextField birthdayField;
+    @FXML
+    private ScrollPane groupList;
+    @FXML
+    private TextField groupSearch;
+    @FXML
+    private ScrollPane groupResults;
 
-
+    private PersonEditDialogModel model;
     private Stage dialogStage;
     private Person person;
     private boolean okClicked = false;
     private ModelManager modelManager;
+
+    public PersonEditDialogController() {
+    }
 
     /**
      * Initializes the controller class. This method is automatically called
@@ -40,6 +202,39 @@ public class PersonEditDialogController {
      */
     @FXML
     private void initialize() {
+        addListener();
+        EventManager.getInstance().registerHandler(this);
+    }
+
+    private void addListener() {
+        groupSearch.textProperty().addListener((observableValue, oldValue, newValue) -> {
+                handleInput(newValue);
+            });
+        groupSearch.setOnKeyTyped(e -> {
+            switch (e.getCharacter()) {
+                case " ":
+                    e.consume();
+                    model.toggleSelection();
+                    groupSearch.clear();
+                    break;
+                default:
+                    break;
+            }
+        });
+        groupSearch.setOnKeyPressed(e -> {
+            switch (e.getCode()) {
+                case DOWN:
+                    e.consume();
+                    model.selectNext();
+                    break;
+                case UP:
+                    e.consume();
+                    model.selectPrevious();
+                    break;
+                default:
+                    break;
+            }
+        });
     }
 
     /**
@@ -57,7 +252,7 @@ public class PersonEditDialogController {
 
     /**
      * Sets the person to be edited in the dialog.
-     * 
+     *
      * @param person
      */
     public void setPerson(Person person) {
@@ -70,6 +265,25 @@ public class PersonEditDialogController {
         cityField.setText(person.getCity());
         birthdayField.setText(DateUtil.format(person.getBirthday()));
         birthdayField.setPromptText("dd.mm.yyyy");
+    }
+
+    public void setModel(List<ContactGroup> contactGroups, List<ContactGroup> assignedGroups) {
+        model = new PersonEditDialogModel(contactGroups, assignedGroups);
+    }
+
+    private VBox getContactGroupsVBox(List<SelectableContactGroup> contactGroupList, boolean isSelectable) {
+        VBox content = new VBox();
+        contactGroupList.stream()
+                .forEach(contactGroup -> {
+                    Label newLabel = new Label(contactGroup.getName());
+                    if (isSelectable && contactGroup.isSelected()) {
+                        newLabel.setStyle("-fx-background-color: blue;");
+                    }
+                    newLabel.setPrefWidth(261);
+                    content.getChildren().add(newLabel);
+                });
+
+        return content;
     }
 
     /**
@@ -96,11 +310,17 @@ public class PersonEditDialogController {
             updated.setPostalCode(Integer.parseInt(postalCodeField.getText()));
             updated.setCity(cityField.getText());
             updated.setBirthday(DateUtil.parse(birthdayField.getText()));
+            updated.setContactGroups(model.getAssignedGroups());
             modelManager.updatePerson(person, updated);
 
             okClicked = true;
             dialogStage.close();
         }
+    }
+
+    @FXML
+    private void handleInput(String newInput) {
+        model.setFilter(newInput);
     }
 
     /**
@@ -166,5 +386,15 @@ public class PersonEditDialogController {
             
             return false;
         }
+    }
+
+    @Subscribe
+    public void handleGroupSearchResultsChangedEvent(GroupSearchResultsChangedEvent e) {
+        groupResults.setContent(getContactGroupsVBox(e.getSelectableContactGroups(), true));
+    }
+
+    @Subscribe
+    public void handleGroupsChangedEvent(GroupsChangedEvent e) {
+        groupList.setContent(getContactGroupsVBox(e.getResultGroup(), false));
     }
 }

--- a/src/main/java/address/controller/PersonOverviewController.java
+++ b/src/main/java/address/controller/PersonOverviewController.java
@@ -6,6 +6,7 @@ import address.events.EventManager;
 import address.events.FilterCommittedEvent;
 import address.events.FilterParseErrorEvent;
 import address.events.FilterSuccessEvent;
+import address.model.ContactGroup;
 import address.model.ModelManager;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
@@ -14,6 +15,8 @@ import javafx.scene.control.TableView;
 import address.model.Person;
 import address.util.DateUtil;
 import javafx.scene.control.TextField;
+
+import java.util.List;
 
 public class PersonOverviewController {
     @FXML
@@ -38,6 +41,8 @@ public class PersonOverviewController {
     private Label cityLabel;
     @FXML
     private Label birthdayLabel;
+    @FXML
+    private Label contactGroupLabel;
 
     private MainController mainController;
     private ModelManager modelManager;
@@ -70,6 +75,17 @@ public class PersonOverviewController {
         // Add observable list data to the table
         personTable.setItems(modelManager.getPersonData());
     }
+
+    private String getContactGroupsString(List<ContactGroup> contactGroups) {
+        String contactGroupsString = "";
+        for (int i = 0; i < contactGroups.size(); i++) {
+            if (i > 0) {
+                contactGroupsString += ", ";
+            }
+            contactGroupsString += contactGroups.get(i).getName();
+        }
+        return contactGroupsString;
+    }
     
     /**
      * Fills all text fields to show details about the person.
@@ -86,6 +102,8 @@ public class PersonOverviewController {
             postalCodeLabel.setText(Integer.toString(person.getPostalCode()));
             cityLabel.setText(person.getCity());
             birthdayLabel.setText(DateUtil.format(person.getBirthday()));
+            List<ContactGroup> contactGroups = person.getContactGroups();
+            contactGroupLabel.setText(getContactGroupsString(contactGroups));
         } else {
             // Person is null, remove all the text.
             firstNameLabel.setText("");
@@ -94,6 +112,7 @@ public class PersonOverviewController {
             postalCodeLabel.setText("");
             cityLabel.setText("");
             birthdayLabel.setText("");
+            contactGroupLabel.setText("");
         }
     }
     

--- a/src/main/java/address/controller/RootLayoutController.java
+++ b/src/main/java/address/controller/RootLayoutController.java
@@ -59,7 +59,7 @@ public class RootLayoutController {
     private void handleSave() {
         File personFile = PreferencesManager.getInstance().getPersonFilePath();
         if (personFile != null) {
-            EventManager.getInstance().post(new SaveRequestEvent(personFile, modelManager.getPersonData()));
+            EventManager.getInstance().post(new SaveRequestEvent(personFile, modelManager.getPersonData(), modelManager.getContactGroups()));
         } else {
             handleSaveAs();
         }
@@ -80,7 +80,7 @@ public class RootLayoutController {
             if (!file.getPath().endsWith(".xml")) {
                 file = new File(file.getPath() + ".xml");
             }
-            EventManager.getInstance().post(new SaveRequestEvent(file, modelManager.getPersonData()));
+            EventManager.getInstance().post(new SaveRequestEvent(file, modelManager.getPersonData(), modelManager.getContactGroups()));
         }
     }
 

--- a/src/main/java/address/controller/RootLayoutController.java
+++ b/src/main/java/address/controller/RootLayoutController.java
@@ -33,7 +33,7 @@ public class RootLayoutController {
     @FXML
     private void handleNew() {
         modelManager.getPersonData().clear();
-        PreferencesManager.getInstance().setPersonFilePath(null);
+        PreferencesManager.getInstance().setFilePath(null);
     }
 
     /**

--- a/src/main/java/address/events/GroupSearchResultsChangedEvent.java
+++ b/src/main/java/address/events/GroupSearchResultsChangedEvent.java
@@ -1,6 +1,6 @@
 package address.events;
 
-import address.controller.PersonEditDialogController.SelectableContactGroup;
+import address.model.SelectableContactGroup;
 
 import java.util.List;
 

--- a/src/main/java/address/events/GroupSearchResultsChangedEvent.java
+++ b/src/main/java/address/events/GroupSearchResultsChangedEvent.java
@@ -1,0 +1,18 @@
+package address.events;
+
+import address.controller.PersonEditDialogController.SelectableContactGroup;
+
+import java.util.List;
+
+public class GroupSearchResultsChangedEvent {
+    List<SelectableContactGroup> selectableContactGroups;
+
+    public GroupSearchResultsChangedEvent(List<SelectableContactGroup> selectableContactGroups) {
+        this.selectableContactGroups = selectableContactGroups;
+    }
+
+    public List<SelectableContactGroup> getSelectableContactGroups() {
+        return this.selectableContactGroups;
+    }
+
+}

--- a/src/main/java/address/events/GroupsChangedEvent.java
+++ b/src/main/java/address/events/GroupsChangedEvent.java
@@ -1,6 +1,6 @@
 package address.events;
 
-import address.controller.PersonEditDialogController.SelectableContactGroup;
+import address.model.SelectableContactGroup;
 
 import java.util.List;
 

--- a/src/main/java/address/events/GroupsChangedEvent.java
+++ b/src/main/java/address/events/GroupsChangedEvent.java
@@ -1,0 +1,17 @@
+package address.events;
+
+import address.controller.PersonEditDialogController.SelectableContactGroup;
+
+import java.util.List;
+
+public class GroupsChangedEvent {
+    List<SelectableContactGroup> resultGroup;
+
+    public GroupsChangedEvent(List<SelectableContactGroup> resultGroup) {
+        this.resultGroup = resultGroup;
+    }
+
+    public List<SelectableContactGroup> getResultGroup() {
+        return this.resultGroup;
+    }
+}

--- a/src/main/java/address/events/LocalModelChangedEvent.java
+++ b/src/main/java/address/events/LocalModelChangedEvent.java
@@ -1,5 +1,6 @@
 package address.events;
 
+import address.model.ContactGroup;
 import address.model.Person;
 
 import java.util.List;
@@ -8,9 +9,11 @@ import java.util.List;
 public class LocalModelChangedEvent {
 
     public List<Person> personData;
+    public List<ContactGroup> groupData;
 
-    public LocalModelChangedEvent(List<Person> personData){
+    public LocalModelChangedEvent(List<Person> personData, List<ContactGroup> groupData){
         this.personData = personData;
+        this.groupData = groupData;
     }
 
     @Override

--- a/src/main/java/address/events/LocalModelSyncedEvent.java
+++ b/src/main/java/address/events/LocalModelSyncedEvent.java
@@ -1,5 +1,6 @@
 package address.events;
 
+import address.model.ContactGroup;
 import address.model.Person;
 
 import java.util.List;
@@ -9,8 +10,11 @@ public class LocalModelSyncedEvent {
 
     public List<Person> personData;
 
-    public LocalModelSyncedEvent(List<Person> personData){
+    public List<ContactGroup> groupData;
+
+    public LocalModelSyncedEvent(List<Person> personData, List<ContactGroup> groupData) {
         this.personData = personData;
+        this.groupData = groupData;
     }
 
     @Override

--- a/src/main/java/address/events/NewMirrorDataEvent.java
+++ b/src/main/java/address/events/NewMirrorDataEvent.java
@@ -1,5 +1,6 @@
 package address.events;
 
+import address.model.AddressBookWrapper;
 import address.model.Person;
 
 import java.util.List;
@@ -7,10 +8,10 @@ import java.util.List;
 /** Indicates some new data is available from the mirror*/
 public class NewMirrorDataEvent {
 
-    public List<Person> personData;
+    public AddressBookWrapper data;
 
-    public NewMirrorDataEvent(List<Person> personData){
-        this.personData = personData;
+    public NewMirrorDataEvent(AddressBookWrapper data){
+        this.data = data;
     }
 
     @Override

--- a/src/main/java/address/events/NewMirrorDataEvent.java
+++ b/src/main/java/address/events/NewMirrorDataEvent.java
@@ -16,6 +16,7 @@ public class NewMirrorDataEvent {
 
     @Override
     public String toString(){
-        return this.getClass().getSimpleName() + " : number of persons " + personData.size();
+        return this.getClass().getSimpleName() + " : number of persons " + data.getPersons().size()
+                + ", number of groups " + data.getGroups().size();
     }
 }

--- a/src/main/java/address/events/SaveRequestEvent.java
+++ b/src/main/java/address/events/SaveRequestEvent.java
@@ -1,5 +1,6 @@
 package address.events;
 
+import address.model.ContactGroup;
 import address.model.Person;
 
 import java.io.File;
@@ -15,10 +16,12 @@ public class SaveRequestEvent {
 
     /** The data to be saved*/
     public List<Person> personData;
+    public List<ContactGroup> groupData;
 
-    public SaveRequestEvent(File file, List<Person> personData){
+    public SaveRequestEvent(File file, List<Person> personData, List<ContactGroup> groupData){
         this.file = file;
         this.personData = personData;
+        this.groupData = groupData;
     }
 
     @Override

--- a/src/main/java/address/model/AddressBookWrapper.java
+++ b/src/main/java/address/model/AddressBookWrapper.java
@@ -11,17 +11,27 @@ import javax.xml.bind.annotation.XmlRootElement;
  * 
  * @author Marco Jakob
  */
-@XmlRootElement(name = "persons")
-public class PersonListWrapper {
+@XmlRootElement(name = "addressbook")
+public class AddressBookWrapper {
 
     private List<Person> persons;
+    private List<ContactGroup> groups;
 
     @XmlElement(name = "person")
     public List<Person> getPersons() {
         return persons;
     }
 
+    @XmlElement(name = "groups")
+    public List<ContactGroup> getGroups() {
+        return groups;
+    }
+
     public void setPersons(List<Person> persons) {
         this.persons = persons;
+    }
+
+    public void setGroups(List<ContactGroup> groups) {
+        this.groups = groups;
     }
 }

--- a/src/main/java/address/model/ContactGroup.java
+++ b/src/main/java/address/model/ContactGroup.java
@@ -5,14 +5,22 @@ import javafx.beans.property.SimpleStringProperty;
 public class ContactGroup {
     SimpleStringProperty name;
 
+    public ContactGroup() {
+    }
+
     public ContactGroup(String name) {
         this.name = new SimpleStringProperty(name);
     }
+
     public String getName() {
         return name.get();
     }
 
     public void setName(String name) {
         this.name = new SimpleStringProperty(name);
+    }
+
+    public void update(ContactGroup group) {
+        setName(group.getName());
     }
 }

--- a/src/main/java/address/model/ContactGroup.java
+++ b/src/main/java/address/model/ContactGroup.java
@@ -1,0 +1,18 @@
+package address.model;
+
+import javafx.beans.property.SimpleStringProperty;
+
+public class ContactGroup {
+    SimpleStringProperty name;
+
+    public ContactGroup(String name) {
+        this.name = new SimpleStringProperty(name);
+    }
+    public String getName() {
+        return name.get();
+    }
+
+    public void setName(String name) {
+        this.name = new SimpleStringProperty(name);
+    }
+}

--- a/src/main/java/address/model/ContactGroup.java
+++ b/src/main/java/address/model/ContactGroup.java
@@ -23,4 +23,9 @@ public class ContactGroup {
     public void update(ContactGroup group) {
         setName(group.getName());
     }
+
+    @Override
+    public boolean equals(Object otherGroup){
+        return this.getName().equals(((ContactGroup) otherGroup).getName());
+    }
 }

--- a/src/main/java/address/model/ModelManager.java
+++ b/src/main/java/address/model/ModelManager.java
@@ -19,6 +19,7 @@ import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,6 +33,7 @@ public class ModelManager {
      */
     private final ObservableList<Person> personData = FXCollections.observableArrayList();
     private final FilteredList<Person> filteredPersonData = new FilteredList<>(personData);
+    private final List<ContactGroup> contactGroups = new ArrayList<>();
 
     /**
      * @param initialData Initial data to populate the model. If the list is
@@ -66,6 +68,9 @@ public class ModelManager {
         personData.add(new Person("Anna", "Best"));
         personData.add(new Person("Stefan", "Meier"));
         personData.add(new Person("Martin", "Mueller"));
+
+        contactGroups.add(new ContactGroup("relatives"));
+        contactGroups.add(new ContactGroup("friends"));
     }
 
     /**
@@ -74,6 +79,14 @@ public class ModelManager {
      */
     public ObservableList<Person> getPersonData() {
         return filteredPersonData;
+    }
+
+    /**
+     * Returns the contact groups as a list.
+     * @return
+     */
+    public List<ContactGroup> getContactGroups() {
+        return contactGroups;
     }
 
     /**

--- a/src/main/java/address/model/Person.java
+++ b/src/main/java/address/model/Person.java
@@ -1,10 +1,18 @@
 package address.model;
 
 import address.util.LocalDateAdapter;
-import javafx.beans.property.*;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
 
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-import java.time.LocalDate;
 
 /**
  * Model class for a Person.
@@ -19,6 +27,7 @@ public class Person {
     private final IntegerProperty postalCode;
     private final StringProperty city;
     private final ObjectProperty<LocalDate> birthday;
+    private final List<ContactGroup> contactGroups;
 
     /**
      * Default constructor.
@@ -42,6 +51,8 @@ public class Person {
         this.postalCode = new SimpleIntegerProperty(1234);
         this.city = new SimpleStringProperty("some city");
         this.birthday = new SimpleObjectProperty<>(LocalDate.of(1999, 2, 21));
+        this.contactGroups = new ArrayList<>();
+        contactGroups.add(new ContactGroup("friends"));
     }
 
     /**
@@ -56,6 +67,16 @@ public class Person {
         this.postalCode = new SimpleIntegerProperty(person.getPostalCode());
         this.city = new SimpleStringProperty(person.getCity());
         this.birthday = new SimpleObjectProperty<>(person.getBirthday());
+        this.contactGroups = new ArrayList<>(person.getContactGroups());
+    }
+
+    public List<ContactGroup> getContactGroups() {
+        return contactGroups;
+    }
+
+    public void setContactGroups(List<ContactGroup> contactGroups) {
+        this.contactGroups.clear();
+        this.contactGroups.addAll(contactGroups);
     }
 
     public String getFirstName() {

--- a/src/main/java/address/model/Person.java
+++ b/src/main/java/address/model/Person.java
@@ -191,5 +191,6 @@ public class Person {
         setPostalCode(updated.getPostalCode());
         setCity(updated.getCity());
         setBirthday(updated.getBirthday());
+        setContactGroups(updated.getContactGroups());
     }
 }

--- a/src/main/java/address/model/PersonEditDialogModel.java
+++ b/src/main/java/address/model/PersonEditDialogModel.java
@@ -17,8 +17,6 @@ public class PersonEditDialogModel {
     List<SelectableContactGroup> assignedGroups = new ArrayList<>();
 
     public PersonEditDialogModel(List<ContactGroup> groups, List<ContactGroup> assignedGroups) {
-        System.err.println("Total of " + groups.size() + " contact groups.");
-        System.err.println(assignedGroups.size() + " groups assigned.");
         List<SelectableContactGroup> selectableContactGroups = groups.stream()
                                                                 .map(SelectableContactGroup::new)
                                                                 .collect(Collectors.toList());

--- a/src/main/java/address/model/PersonEditDialogModel.java
+++ b/src/main/java/address/model/PersonEditDialogModel.java
@@ -1,0 +1,134 @@
+package address.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import address.events.EventManager;
+import address.events.GroupSearchResultsChangedEvent;
+import address.events.GroupsChangedEvent;
+
+public class PersonEditDialogModel {
+    List<SelectableContactGroup> groups = new ArrayList<>();
+    List<SelectableContactGroup> filteredGroups = new ArrayList<>();
+    Optional<Integer> selectedGroupIndex = Optional.empty();
+
+    List<SelectableContactGroup> assignedGroups = new ArrayList<>();
+
+    public PersonEditDialogModel(List<ContactGroup> groups, List<ContactGroup> assignedGroups) {
+        List<SelectableContactGroup> selectableContactGroups = groups.stream()
+                                                                .map(SelectableContactGroup::new)
+                                                                .collect(Collectors.toList());
+        this.groups.addAll(selectableContactGroups);
+
+        assignedGroups.stream()
+                .forEach(assignedGroup -> this.assignedGroups.addAll(this.groups.stream()
+                        .filter(group -> group.getName().equals(assignedGroup.getName()))
+                        .collect(Collectors.toList())));
+
+        EventManager.getInstance().post(new GroupsChangedEvent(this.assignedGroups));
+        setFilter("");
+    }
+
+    private Optional<SelectableContactGroup> getSelection() {
+        return filteredGroups.stream()
+                .filter(SelectableContactGroup::isSelected)
+                .findFirst();
+    }
+
+    public void toggleSelection() {
+        Optional<SelectableContactGroup> selection = getSelection();
+        if (!selection.isPresent()) return;
+
+        if (assignedGroups.contains(selection.get())) {
+            assignedGroups.remove(selection.get());
+        } else {
+            assignedGroups.add(selection.get());
+        }
+
+        EventManager.getInstance().post(new GroupsChangedEvent(assignedGroups));
+    }
+
+    private void selectIndex(int index) {
+        clearSelection();
+        SelectableContactGroup group = filteredGroups.remove(index);
+        group.setSelected(true);
+        filteredGroups.add(index, group);
+    }
+
+    private void clearSelection() {
+        for (int i = 0; i < filteredGroups.size(); i++) {
+            if (filteredGroups.get(i).isSelected()) {
+                SelectableContactGroup group = filteredGroups.remove(i);
+                group.setSelected(false);
+                filteredGroups.add(i, group);
+            }
+        }
+    }
+
+    public void selectNext() {
+        if (!canIncreaseIndex()) return;
+        selectedGroupIndex = Optional.of(selectedGroupIndex.orElse(-1) + 1);
+        updateSelection();
+        EventManager.getInstance().post(new GroupSearchResultsChangedEvent(filteredGroups));
+    }
+
+    private void updateSelection() {
+        if (selectedGroupIndex.isPresent()) {
+            selectIndex(selectedGroupIndex.get());
+        } else {
+            clearSelection();
+        }
+    }
+
+    private boolean canIncreaseIndex() {
+        return !filteredGroups.isEmpty()
+                && (!selectedGroupIndex.isPresent() || selectedGroupIndex.get() < filteredGroups.size() - 1);
+    }
+
+    public void selectPrevious() {
+        if (!canDecreaseIndex()) return;
+        selectedGroupIndex = Optional.of(selectedGroupIndex.get() - 1);
+        updateSelection();
+        EventManager.getInstance().post(new GroupSearchResultsChangedEvent(filteredGroups));
+    }
+
+    private boolean canDecreaseIndex() {
+        return selectedGroupIndex.isPresent() && selectedGroupIndex.get() > 0;
+    }
+
+    public void setFilter(String filter) {
+
+        List<SelectableContactGroup> newContactGroups = groups.stream()
+                .filter(group -> group.getName().contains(filter))
+                .collect(Collectors.toList());
+
+        List<SelectableContactGroup> toBeAdded = newContactGroups.stream()
+                .filter(newContactGroup -> !filteredGroups.contains(newContactGroup))
+                .collect(Collectors.toList());
+        List<SelectableContactGroup> toBeRemoved = filteredGroups.stream()
+                .filter(oldContactGroup -> !newContactGroups.contains(oldContactGroup))
+                .collect(Collectors.toList());
+
+        toBeRemoved.stream()
+                .forEach(toRemove -> filteredGroups.remove(toRemove));
+        toBeAdded.stream()
+                .forEach(toAdd -> filteredGroups.add(toAdd));
+
+        if (!filter.isEmpty() && !filteredGroups.isEmpty()) {
+            selectedGroupIndex = Optional.of(0);
+        } else {
+            selectedGroupIndex = Optional.empty();
+        }
+        updateSelection();
+
+        EventManager.getInstance().post(new GroupSearchResultsChangedEvent(filteredGroups));
+    }
+
+    public List<ContactGroup> getAssignedGroups() {
+        return assignedGroups.stream()
+                .map(assignedGroup -> new ContactGroup(assignedGroup.getName()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/address/model/PersonEditDialogModel.java
+++ b/src/main/java/address/model/PersonEditDialogModel.java
@@ -17,6 +17,8 @@ public class PersonEditDialogModel {
     List<SelectableContactGroup> assignedGroups = new ArrayList<>();
 
     public PersonEditDialogModel(List<ContactGroup> groups, List<ContactGroup> assignedGroups) {
+        System.err.println("Total of " + groups.size() + " contact groups.");
+        System.err.println(assignedGroups.size() + " groups assigned.");
         List<SelectableContactGroup> selectableContactGroups = groups.stream()
                                                                 .map(SelectableContactGroup::new)
                                                                 .collect(Collectors.toList());

--- a/src/main/java/address/model/SelectableContactGroup.java
+++ b/src/main/java/address/model/SelectableContactGroup.java
@@ -1,0 +1,17 @@
+package address.model;
+
+public class SelectableContactGroup extends ContactGroup {
+    private boolean isSelected = false;
+
+    public SelectableContactGroup(ContactGroup contactGroup) {
+        super(contactGroup.getName());
+    }
+
+    public void setSelected(boolean isSelected) {
+        this.isSelected = isSelected;
+    }
+
+    public boolean isSelected() {
+        return this.isSelected;
+    }
+}

--- a/src/main/java/address/preferences/PreferencesManager.java
+++ b/src/main/java/address/preferences/PreferencesManager.java
@@ -43,7 +43,7 @@ public class PreferencesManager {
      *
      * @param file the file or null to remove the path
      */
-    public void setPersonFilePath(File file) {
+    public void setFilePath(File file) {
         java.util.prefs.Preferences prefs = java.util.prefs.Preferences.userNodeForPackage(PreferencesManager.class);
         if (file != null) {
             prefs.put(REGISTER_FILE_PATH, file.getPath());

--- a/src/main/java/address/storage/StorageManager.java
+++ b/src/main/java/address/storage/StorageManager.java
@@ -10,7 +10,6 @@ import address.util.XmlHelper;
 import com.google.common.eventbus.Subscribe;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 
@@ -21,7 +20,6 @@ public class StorageManager {
 
     public StorageManager(ModelManager modelManager){
         EventManager.getInstance().registerHandler(this);
-
     }
 
 
@@ -36,7 +34,7 @@ public class StorageManager {
         modelManager.resetData(data.getPersons(), data.getGroups());
 
         // Save the file path to the registry.
-        PreferencesManager.getInstance().setPersonFilePath(file);
+        PreferencesManager.getInstance().setFilePath(file);
     }
 
 
@@ -55,12 +53,12 @@ public class StorageManager {
      *
      * @param file
      */
-    public void savePersonDataToFile(File file, List<Person> personData, List<ContactGroup> groupData) {
+    public void saveDataToFile(File file, List<Person> personData, List<ContactGroup> groupData) {
         try {
             XmlHelper.saveToFile(file, personData, groupData);
 
             // Save the file path to the registry.
-            PreferencesManager.getInstance().setPersonFilePath(file);
+            PreferencesManager.getInstance().setFilePath(file);
 
         } catch (Exception e) {
             EventManager.getInstance().post(new FileSavingExceptionEvent(e,file));
@@ -70,18 +68,18 @@ public class StorageManager {
     @Subscribe
     private void handleLocalModelChangedEvent(LocalModelChangedEvent lmce){
         System.out.println("Local data changed, saving to primary data file");
-        savePersonDataToFile(PreferencesManager.getInstance().getPersonFilePath(), lmce.personData, lmce.groupData);
+        saveDataToFile(PreferencesManager.getInstance().getPersonFilePath(), lmce.personData, lmce.groupData);
     }
 
     @Subscribe
     private void handleLocalModelSyncedEvent(LocalModelSyncedEvent lmse){
         System.out.println("Local data synced, saving to primary data file");
-        savePersonDataToFile(PreferencesManager.getInstance().getPersonFilePath(), lmse.personData, lmse.groupData);
+        saveDataToFile(PreferencesManager.getInstance().getPersonFilePath(), lmse.personData, lmse.groupData);
     }
 
     @Subscribe
     private void handleSaveRequestEvent(SaveRequestEvent se){
-        savePersonDataToFile(se.file, se.personData, se.groupData);
+        saveDataToFile(se.file, se.personData, se.groupData);
     }
 
     /**

--- a/src/main/java/address/storage/StorageManager.java
+++ b/src/main/java/address/storage/StorageManager.java
@@ -1,6 +1,8 @@
 package address.storage;
 
 import address.events.*;
+import address.model.AddressBookWrapper;
+import address.model.ContactGroup;
 import address.model.ModelManager;
 import address.model.Person;
 import address.preferences.PreferencesManager;
@@ -29,9 +31,9 @@ public class StorageManager {
      *
      */
     public void loadPersonDataFromFile(File file) throws Exception {
-        List<Person> data  = XmlHelper.getDataFromFile(file);
+        AddressBookWrapper data  = XmlHelper.getDataFromFile(file);
 
-        modelManager.resetData(data);
+        modelManager.resetData(data.getPersons(), data.getGroups());
 
         // Save the file path to the registry.
         PreferencesManager.getInstance().setPersonFilePath(file);
@@ -53,9 +55,9 @@ public class StorageManager {
      *
      * @param file
      */
-    public void savePersonDataToFile(File file, List<Person> personData) {
+    public void savePersonDataToFile(File file, List<Person> personData, List<ContactGroup> groupData) {
         try {
-            XmlHelper.saveToFile(file, personData);
+            XmlHelper.saveToFile(file, personData, groupData);
 
             // Save the file path to the registry.
             PreferencesManager.getInstance().setPersonFilePath(file);
@@ -68,18 +70,18 @@ public class StorageManager {
     @Subscribe
     private void handleLocalModelChangedEvent(LocalModelChangedEvent lmce){
         System.out.println("Local data changed, saving to primary data file");
-        savePersonDataToFile(PreferencesManager.getInstance().getPersonFilePath(), lmce.personData);
+        savePersonDataToFile(PreferencesManager.getInstance().getPersonFilePath(), lmce.personData, lmce.groupData);
     }
 
     @Subscribe
     private void handleLocalModelSyncedEvent(LocalModelSyncedEvent lmse){
         System.out.println("Local data synced, saving to primary data file");
-        savePersonDataToFile(PreferencesManager.getInstance().getPersonFilePath(), lmse.personData);
+        savePersonDataToFile(PreferencesManager.getInstance().getPersonFilePath(), lmse.personData, lmse.groupData);
     }
 
     @Subscribe
     private void handleSaveRequestEvent(SaveRequestEvent se){
-        savePersonDataToFile(se.file, se.personData);
+        savePersonDataToFile(se.file, se.personData, se.groupData);
     }
 
     /**
@@ -88,12 +90,12 @@ public class StorageManager {
      * @param file File containing the data
      * @return Person list in the file
      */
-    public static List<Person> getPersonDataFromFile(File file)  {
+    public static AddressBookWrapper getDataFromFile(File file)  {
         try {
             return file == null ? null : XmlHelper.getDataFromFile(file);
         } catch (Exception e) {
             EventManager.getInstance().post(new FileOpeningExceptionEvent(e, file));
-            return Collections.emptyList();
+            return new AddressBookWrapper();
         }
     }
 

--- a/src/main/java/address/sync/CloudSimulator.java
+++ b/src/main/java/address/sync/CloudSimulator.java
@@ -1,5 +1,7 @@
 package address.sync;
 
+import address.model.AddressBookWrapper;
+import address.model.ContactGroup;
 import address.model.Person;
 import address.util.XmlHelper;
 
@@ -33,23 +35,26 @@ public class CloudSimulator {
      * The data is possibly modified in each call to this method and is persisted onto the same file.
      * When failure condition occurs, this returns an empty data set.
      */
-    public List<Person> getSimulatedCloudData(File file) {
+    public AddressBookWrapper getSimulatedCloudData(File file) {
         System.out.println("Simulating cloud data retrieval...");
-        List<Person> modifiedData = new ArrayList<>();
+        AddressBookWrapper modifiedData = new AddressBookWrapper();
         try {
-            List<Person> data = XmlHelper.getDataFromFile(file);
+            AddressBookWrapper data = XmlHelper.getDataFromFile(file);
             if (!this.isSimulateRandomChanges) {
                 return data;
             }
 
             if (random.nextDouble() <= FAILURE_PROBABILITY) {
                 System.out.println("Cloud simulator: failure occurred!");
-                return new ArrayList<>();
+                AddressBookWrapper wrapper = new AddressBookWrapper();
+                wrapper.setPersons(new ArrayList<>());
+                wrapper.setGroups(new ArrayList<>());
+                return wrapper;
             }
 
             modifiedData = simulateDataModification(data);
-            modifiedData.addAll(simulateDataAddition());
-            XmlHelper.saveToFile(file, modifiedData);
+            modifiedData.getPersons().addAll(simulateDataAddition());
+            XmlHelper.saveToFile(file, modifiedData.getPersons(), modifiedData.getGroups());
             TimeUnit.SECONDS.sleep(random.nextInt(DELAY_RANGE) + MIN_DELAY_IN_SEC);
         } catch (JAXBException e) {
             System.out.println("File not found or is not in valid xml format : " + file);
@@ -64,8 +69,8 @@ public class CloudSimulator {
      * written to the provided mirror file
      * @param delay Duration of delay in seconds to be simulated before the request is completed
      */
-    public void requestChangesToCloud(File file, List<Person> data, int delay) throws JAXBException {
-        XmlHelper.saveToFile(file, data);
+    public void requestChangesToCloud(File file, List<Person> data, List<ContactGroup> groups, int delay) throws JAXBException {
+        XmlHelper.saveToFile(file, data, groups);
         try {
             TimeUnit.SECONDS.sleep(delay);
         } catch (InterruptedException e) {
@@ -88,10 +93,11 @@ public class CloudSimulator {
         return newData;
     }
 
-    private List<Person> simulateDataModification(List<Person> data) {
+    private AddressBookWrapper simulateDataModification(AddressBookWrapper data) {
         List<Person> modifiedData = new ArrayList<>();
 
-        for (Person person : data) {
+        // currently only modifies persons
+        for (Person person : data.getPersons()) {
             if (random.nextDouble() <= MODIFY_PERSON_PROBABILITY) {
                 System.out.println("Cloud simulator: modifying " + person);
                 person.setCity(java.util.UUID.randomUUID().toString());
@@ -101,6 +107,7 @@ public class CloudSimulator {
             modifiedData.add(person);
         }
 
-        return modifiedData;
+        data.setPersons(modifiedData);
+        return data;
     }
 }

--- a/src/main/java/address/sync/SyncManager.java
+++ b/src/main/java/address/sync/SyncManager.java
@@ -4,6 +4,7 @@ package address.sync;
 import address.events.EventManager;
 import address.events.LocalModelChangedEvent;
 import address.events.NewMirrorDataEvent;
+import address.model.AddressBookWrapper;
 import address.model.Person;
 import address.preferences.PreferencesManager;
 import address.sync.task.CloudUpdateTask;
@@ -53,9 +54,9 @@ public class SyncManager {
      */
     public void updatePeriodically(long interval) {
         Runnable task = () -> {
-            List<Person> mirrorData = getMirrorData();
+            AddressBookWrapper mirrorData = getMirrorData();
 
-            if(!mirrorData.isEmpty()) {
+            if (!mirrorData.getPersons().isEmpty() || !mirrorData.getGroups().isEmpty()) {
                 EventManager.getInstance().post(new NewMirrorDataEvent(mirrorData));
             }
         };
@@ -64,7 +65,7 @@ public class SyncManager {
         scheduler.scheduleAtFixedRate(task, initialDelay, interval, TimeUnit.SECONDS);
     }
 
-    private List<Person> getMirrorData() {
+    private AddressBookWrapper getMirrorData() {
         System.out.println("Updating data: " + System.nanoTime());
         File mirrorFile = new File(PreferencesManager.getInstance().getPersonFilePath().toString() + "-mirror.xml");
         return this.cloudSimulator.getSimulatedCloudData(mirrorFile);
@@ -72,6 +73,6 @@ public class SyncManager {
 
     @Subscribe
     public void handleLocalModelChangedEvent(LocalModelChangedEvent lmce) {
-        requestExecutor.execute(new CloudUpdateTask(this.cloudSimulator, lmce.personData));
+        requestExecutor.execute(new CloudUpdateTask(this.cloudSimulator, lmce.personData, lmce.groupData));
     }
 }

--- a/src/main/java/address/sync/task/CloudUpdateTask.java
+++ b/src/main/java/address/sync/task/CloudUpdateTask.java
@@ -1,5 +1,6 @@
 package address.sync.task;
 
+import address.model.ContactGroup;
 import address.model.Person;
 import address.preferences.PreferencesManager;
 import address.sync.CloudSimulator;
@@ -10,11 +11,13 @@ import java.util.List;
 
 public class CloudUpdateTask implements Runnable {
     private final CloudSimulator simulator;
-    private final List<Person> data;
+    private final List<Person> personsData;
+    private final List<ContactGroup> groupsData;
 
-    public CloudUpdateTask(CloudSimulator simulator, List<Person> data) {
+    public CloudUpdateTask(CloudSimulator simulator, List<Person> personsData, List<ContactGroup> groupsData) {
         this.simulator = simulator;
-        this.data = data;
+        this.personsData = personsData;
+        this.groupsData = groupsData;
     }
 
     @Override
@@ -22,7 +25,7 @@ public class CloudUpdateTask implements Runnable {
         System.out.println("Requesting changes to the cloud: " + System.nanoTime());
         File mirrorFile = new File(PreferencesManager.getInstance().getPersonFilePath().toString() + "-mirror.xml");
         try {
-            simulator.requestChangesToCloud(mirrorFile, this.data, 3);
+            simulator.requestChangesToCloud(mirrorFile, this.personsData, this.groupsData, 3);
         } catch (JAXBException e) {
             System.out.println("Error requesting changes to the cloud");
         }

--- a/src/main/java/address/util/XmlHelper.java
+++ b/src/main/java/address/util/XmlHelper.java
@@ -1,7 +1,8 @@
 package address.util;
 
+import address.model.ContactGroup;
 import address.model.Person;
-import address.model.PersonListWrapper;
+import address.model.AddressBookWrapper;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -14,23 +15,24 @@ import java.util.List;
  * Helps with reading from and writing to the XML file.
  */
 public class XmlHelper {
-    public static List<Person> getDataFromFile(File file) throws JAXBException {
+    public static AddressBookWrapper getDataFromFile(File file) throws JAXBException {
         JAXBContext context = JAXBContext
-                .newInstance(PersonListWrapper.class);
+                .newInstance(AddressBookWrapper.class);
         Unmarshaller um = context.createUnmarshaller();
 
         // Reading XML from the file and unmarshalling.
-        return ((PersonListWrapper) um.unmarshal(file)).getPersons();
+        return ((AddressBookWrapper) um.unmarshal(file));
     }
 
-    public static void saveToFile(File file, List<Person> personData) throws JAXBException {
-        JAXBContext context = JAXBContext.newInstance(PersonListWrapper.class);
+    public static void saveToFile(File file, List<Person> personData, List<ContactGroup> groupData) throws JAXBException {
+        JAXBContext context = JAXBContext.newInstance(AddressBookWrapper.class);
         Marshaller m = context.createMarshaller();
         m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 
         // Wrapping our person data.
-        PersonListWrapper wrapper = new PersonListWrapper();
+        AddressBookWrapper wrapper = new AddressBookWrapper();
         wrapper.setPersons(personData);
+        wrapper.setGroups(groupData);
 
         // Marshalling and saving XML to the file.
         m.marshal(wrapper, file);

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -5,7 +5,7 @@
 .label {
     -fx-font-size: 11pt;
     -fx-font-family: "Segoe UI Semibold";
-    -fx-text-fill: white;
+    -fx-text-fill: #555555;
     -fx-opacity: 0.6;
 }
 

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -40,10 +40,10 @@
     -fx-size: 35;
     -fx-border-width: 0 0 1 0;
     -fx-background-color: transparent;
-    -fx-border-color: 
+    -fx-border-color:
         transparent
         transparent
-        derive(-fx-base, 80%) 
+        derive(-fx-base, 80%)
         transparent;
     -fx-border-insets: 0 10 1 0;
 }
@@ -93,13 +93,13 @@
     -fx-font-family: "Segoe UI Semibold";
 }
 
-/* 
+/*
  * Metro style Push Button
  * Author: Pedro Duque Vieira
  * http://pixelduke.wordpress.com/2012/10/23/jmetro-windows-8-controls-on-java/
  */
 .button {
-    -fx-padding: 5 22 5 22;   
+    -fx-padding: 5 22 5 22;
     -fx-border-color: #e2e2e2;
     -fx-border-width: 2;
     -fx-background-radius: 0;

--- a/src/main/resources/view/PersonEditDialog.fxml
+++ b/src/main/resources/view/PersonEditDialog.fxml
@@ -19,9 +19,12 @@
           <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
           <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
           <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+          <RowConstraints minHeight="50.0" prefHeight="50.0" vgrow="SOMETIMES" />
+          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+          <RowConstraints minHeight="50.0" prefHeight="50.0" vgrow="SOMETIMES" />
         </rowConstraints>
          <children>
             <Label text="First Name" />
@@ -30,13 +33,18 @@
             <Label text="City" GridPane.rowIndex="3" />
             <Label text="Postal Code" GridPane.rowIndex="4" />
             <Label text="Birthday" GridPane.rowIndex="5" />
+            <Label text="Contact Group" GridPane.rowIndex="6" />
+            <Label text="Search" GridPane.rowIndex="7" />
+            <Label text="Search Results" GridPane.rowIndex="8" />
             <TextField fx:id="firstNameField" GridPane.columnIndex="1" />
             <TextField fx:id="lastNameField" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-            <TextField GridPane.columnIndex="1" GridPane.rowIndex="2" />
             <TextField fx:id="streetField" GridPane.columnIndex="1" GridPane.rowIndex="2" />
             <TextField fx:id="cityField" GridPane.columnIndex="1" GridPane.rowIndex="3" />
             <TextField fx:id="postalCodeField" GridPane.columnIndex="1" GridPane.rowIndex="4" />
             <TextField fx:id="birthdayField" GridPane.columnIndex="1" GridPane.rowIndex="5" />
+            <ScrollPane fx:id="groupList" GridPane.columnIndex="1" GridPane.rowIndex="6" />
+            <TextField fx:id="groupSearch" GridPane.columnIndex="1" GridPane.rowIndex="7"/>
+            <ScrollPane fx:id="groupResults" GridPane.columnIndex="1" GridPane.rowIndex="8" />
          </children>
       </GridPane>
       <ButtonBar layoutX="176.0" layoutY="233.0" AnchorPane.bottomAnchor="10.0" AnchorPane.rightAnchor="10.0">

--- a/src/main/resources/view/PersonOverview.fxml
+++ b/src/main/resources/view/PersonOverview.fxml
@@ -44,6 +44,7 @@
                                 <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                                 <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                                 <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                             </rowConstraints>
                             <children>
                                 <Label text="First Name" />
@@ -58,6 +59,7 @@
                                 <Label fx:id="cityLabel" styleClass="label-bright" text="Label" GridPane.columnIndex="1" GridPane.rowIndex="3" />
                                 <Label fx:id="postalCodeLabel" styleClass="label-bright" text="Label" GridPane.columnIndex="1" GridPane.rowIndex="4" />
                                 <Label fx:id="birthdayLabel" styleClass="label-bright" text="Label" GridPane.columnIndex="1" GridPane.rowIndex="5" />
+                                <Label fx:id="contactGroupLabel" styleClass="label-bright" text="Label" GridPane.columnIndex="1" GridPane.rowIndex="6" />
                             </children>
                         </GridPane>
                         <ButtonBar layoutX="54.0" layoutY="250.0" AnchorPane.bottomAnchor="10.0" AnchorPane.rightAnchor="10.0">

--- a/src/main/resources/view/PersonOverview.fxml
+++ b/src/main/resources/view/PersonOverview.fxml
@@ -53,6 +53,7 @@
                                 <Label text="City" GridPane.rowIndex="3" />
                                 <Label text="Postal Code" GridPane.rowIndex="4" />
                                 <Label text="Birthday" GridPane.rowIndex="5" />
+                                <Label text="Contact Group" GridPane.rowIndex="6" />
                                 <Label fx:id="firstNameLabel" styleClass="label-bright" text="Label" GridPane.columnIndex="1" />
                                 <Label fx:id="lastNameLabel" styleClass="label-bright" text="Label" GridPane.columnIndex="1" GridPane.rowIndex="1" />
                                 <Label fx:id="streetLabel" styleClass="label-bright" text="Label" GridPane.columnIndex="1" GridPane.rowIndex="2" />


### PR DESCRIPTION
Fixes #9.
![screen shot 2016-05-10 at 3 14 34 pm](https://cloud.githubusercontent.com/assets/12193772/15138387/10d0ca5c-16c2-11e6-81e3-0da18f477f9d.png)
![screen shot 2016-05-10 at 3 14 47 pm](https://cloud.githubusercontent.com/assets/12193772/15138392/167b00e4-16c2-11e6-9e8e-ae1fae682fb8.png)
Space is used to 'toggle'  contact group.

The way this is done is by triggering an event whenever the filtered groups or assigned groups are changed, and this is listened to by the *View* code in `PersonEditDialogController` which updates the `Search Results` and `Contact Group` respectively.

**Done**