### PR TITLE
Delete in mirror file does not delete in original file #30

### DIFF
--- a/src/main/java/address/MainApp.java
+++ b/src/main/java/address/MainApp.java
@@ -21,7 +21,17 @@ public class MainApp extends Application {
     protected SyncManager syncManager;
     private MainController mainController;
 
-    public MainApp() {
+    public MainApp() {}
+
+    protected Config getConfig() {
+        return new Config();
+    }
+
+
+    @Override
+    public void start(Stage primaryStage) {
+        setupComponents();
+        mainController.start(primaryStage);
     }
 
     protected void setupComponents() {
@@ -33,17 +43,6 @@ public class MainApp extends Application {
         mainController = new MainController(modelManager, config);
         syncManager = new SyncManager();
         syncManager.startSyncingData(config.updateInterval, config.isSimulateRandomChanges);
-    }
-
-    protected Config getConfig() {
-        return new Config();
-    }
-
-
-    @Override
-    public void start(Stage primaryStage) {
-        setupComponents();
-        mainController.start(primaryStage);
     }
 
     @Override

--- a/src/main/java/address/sync/CloudSimulator.java
+++ b/src/main/java/address/sync/CloudSimulator.java
@@ -37,17 +37,18 @@ public class CloudSimulator {
      * The data is possibly modified in each call to this method and is persisted onto the same file.
      * When failure condition occurs, this returns an empty data set.
      */
-    public AddressBookWrapper getSimulatedCloudData(File file) {
+    public AddressBookWrapper getSimulatedCloudData(File cloudFile) {
         System.out.println("Simulating cloud data retrieval...");
         AddressBookWrapper modifiedData = new AddressBookWrapper();
         try {
-            AddressBookWrapper data = XmlHelper.getDataFromFile(file);
+            AddressBookWrapper data = XmlHelper.getDataFromFile(cloudFile);
             if (!this.isSimulateRandomChanges) {
                 return data;
             }
 
+            // no data could be retrieved
             if (random.nextDouble() <= FAILURE_PROBABILITY) {
-                System.out.println("Cloud simulator: failure occurred!");
+                System.out.println("Cloud simulator: failure occurred! Could not retrieve data");
                 AddressBookWrapper wrapper = new AddressBookWrapper();
                 wrapper.setPersons(new ArrayList<>());
                 wrapper.setGroups(new ArrayList<>());
@@ -56,10 +57,10 @@ public class CloudSimulator {
 
             modifiedData = simulateDataModification(data);
             modifiedData.getPersons().addAll(simulateDataAddition());
-            XmlHelper.saveToFile(file, modifiedData.getPersons(), modifiedData.getGroups());
+            XmlHelper.saveToFile(cloudFile, modifiedData.getPersons(), modifiedData.getGroups());
             TimeUnit.SECONDS.sleep(random.nextInt(DELAY_RANGE) + MIN_DELAY_IN_SEC);
         } catch (JAXBException e) {
-            System.out.println("File not found or is not in valid xml format : " + file);
+            System.out.println("File not found or is not in valid xml format : " + cloudFile);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
@@ -71,13 +72,13 @@ public class CloudSimulator {
      * written to the provided mirror file
      * @param delay Duration of delay in seconds to be simulated before the request is completed
      */
-    public void requestChangesToCloud(File file, List<Person> data, List<ContactGroup> groups, int delay) throws JAXBException {
+    public void requestChangesToCloud(File file, List<Person> people, List<ContactGroup> groups, int delay) throws JAXBException {
         if (file == null) {
             return;
         }
-        List<Person> persons = data.stream().map(Person::new).collect(Collectors.toList());
+        List<Person> persons = people.stream().map(Person::new).collect(Collectors.toList());
         persons.forEach((p) -> p.setUpdatedAt(LocalDateTime.now()));
-        XmlHelper.saveToFile(file, data, groups);
+        XmlHelper.saveToFile(file, people, groups);
         try {
             TimeUnit.SECONDS.sleep(delay);
         } catch (InterruptedException e) {

--- a/src/main/java/address/sync/SyncManager.java
+++ b/src/main/java/address/sync/SyncManager.java
@@ -42,7 +42,6 @@ public class SyncManager {
         }
     }
 
-
     /**
      * Runs periodically and adds any entries in the mirror file that is missing
      * in the primary data file. The mirror file should be at the same location
@@ -51,7 +50,7 @@ public class SyncManager {
      */
     public void updatePeriodically(long interval) {
         Runnable task = () -> {
-            final AddressBookWrapper mirrorData = getMirrorData();
+            AddressBookWrapper mirrorData = getMirrorData();
 
             if (!mirrorData.getPersons().isEmpty() || !mirrorData.getGroups().isEmpty()) {
                 EventManager.getInstance().post(new NewMirrorDataEvent(mirrorData));
@@ -63,8 +62,8 @@ public class SyncManager {
     }
 
     private AddressBookWrapper getMirrorData() {
-        System.out.println("Updating data: " + System.nanoTime());
-        File mirrorFile = new File(PreferencesManager.getInstance().getPersonFile().toString() + "-mirror.xml");
+        System.out.println("Updating data from cloud: " + System.nanoTime());
+        final File mirrorFile = new File(PreferencesManager.getInstance().getPersonFile().toString() + "-mirror.xml");
         return this.cloudSimulator.getSimulatedCloudData(mirrorFile);
     }
 

--- a/src/main/java/address/util/PlatformEx.java
+++ b/src/main/java/address/util/PlatformEx.java
@@ -1,0 +1,84 @@
+package address.util;
+
+import javafx.application.Platform;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Extensions to JavaFX's Platform class.
+ * <p>
+ * Contains utility methods for running code in various ways,
+ * on or off (but close to) the JavaFX application thread.
+ */
+public final class PlatformEx {
+
+  private static final ExecutorService delayExecutor = Executors.newSingleThreadExecutor();
+
+  /**
+   * Similar to Platform.runLater, but with a small delay, so UI updates have time to propagate.
+   *
+   * @param action
+   */
+  public static void runLaterDelayed(Runnable action) {
+    runLaterDelayed(action, 300);
+  }
+
+  public static void runLaterDelayed(Runnable action, int delay) {
+    delayExecutor.execute(() -> {
+      try {
+        Thread.sleep(delay);
+      } catch (InterruptedException e) {
+        assert false;
+      }
+      Platform.runLater(action);
+    });
+  }
+
+  /**
+   * Blocks until the JavaFX event queue becomes empty.
+   */
+  public static void waitOnFxThread() {
+    runLaterAndWait(() -> {
+    });
+  }
+
+  /**
+   * Runs an action on the JavaFX Application Thread and blocks until it completes.
+   * Similar to {@link #runAndWait(Runnable) runAndWait}, but always enqueues the
+   * action, eschewing checking the current thread.
+   *
+   * @param action The action to run on the JavaFX Application Thread
+   */
+  public static void runLaterAndWait(Runnable action) {
+    assert action != null : "Non-null action required";
+    CountDownLatch latch = new CountDownLatch(1);
+    Platform.runLater(() -> {
+      action.run();
+      latch.countDown();
+    });
+    try {
+      latch.await();
+    } catch (InterruptedException ignored) {
+    }
+  }
+
+  /**
+   * Synchronous version of Platform.runLater, like SwingUtilities.invokeAndWait.
+   * Caveat: will execute immediately when invoked from the JavaFX application thread
+   * instead of being queued up for execution.
+   *
+   * @param action The action to execute on the JavaFX Application Thread.
+   */
+  public static void runAndWait(Runnable action) {
+    assert action != null : "Non-null action required";
+    if (Platform.isFxApplicationThread()) {
+      action.run();
+      return;
+    }
+    runLaterAndWait(action);
+  }
+
+  private PlatformEx() {}
+}


### PR DESCRIPTION
Fixes #30 

1. Shifted model update to fx platform thread
2. Uses `resetData` instead of `addNewData` when loading data from mirror into model.