### PR TITLE
Set the default size of the app to be bigger #47

### DIFF
--- a/src/main/java/address/controller/MainController.java
+++ b/src/main/java/address/controller/MainController.java
@@ -67,6 +67,10 @@ public class MainController {
 
             // Show the scene containing the root layout.
             Scene scene = new Scene(rootLayout);
+            primaryStage.setMinHeight(200);
+            primaryStage.setMinWidth(340);
+            primaryStage.setHeight(600);
+            primaryStage.setWidth(340);
             primaryStage.setScene(scene);
 
             // Give the rootController access to the main controller and modelManager

--- a/src/main/resources/view/PersonOverview.fxml
+++ b/src/main/resources/view/PersonOverview.fxml
@@ -5,17 +5,17 @@
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
-<AnchorPane prefHeight="360.0" prefWidth="340.0" xmlns="http://javafx.com/javafx/8"
+<AnchorPane xmlns="http://javafx.com/javafx/8"
             xmlns:fx="http://javafx.com/fxml/1" fx:controller="address.controller.PersonOverviewController">
     <stylesheets>
         <URL value="@DarkTheme.css" />
         <URL value="@Extensions.css" />
     </stylesheets>
     <children>
-        <VBox minWidth="0.0" prefHeight="363.0" prefWidth="337.0">
+        <VBox AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
             <children>
-                <TextField fx:id="filterField" onAction="#handleFilterChanged" VBox.vgrow="ALWAYS" />
-                <ListView fx:id="personList" prefHeight="282.0" prefWidth="248.0" />
+                <TextField fx:id="filterField" onAction="#handleFilterChanged"/>
+                <ListView fx:id="personList" VBox.vgrow="ALWAYS"/>
                 <HBox>
                     <children>
                         <Button styleClass="button" mnemonicParsing="false" onAction="#handleDeletePerson" prefHeight="33.0" maxWidth="Infinity" HBox.hgrow="ALWAYS" text="Delete" />

--- a/src/main/resources/view/RootLayout.fxml
+++ b/src/main/resources/view/RootLayout.fxml
@@ -2,9 +2,8 @@
 
 <?import java.net.URL?>
 <?import javafx.scene.control.*?>
-<?import javafx.scene.input.KeyCodeCombination?>
 <?import javafx.scene.layout.BorderPane?>
-<BorderPane prefHeight="380.0" prefWidth="340.0" xmlns="http://javafx.com/javafx/8.0.40"
+<BorderPane xmlns="http://javafx.com/javafx/8.0.40"
             xmlns:fx="http://javafx.com/fxml/1" fx:controller="address.controller.RootLayoutController">
   <stylesheets>
     <URL value="@DarkTheme.css" />


### PR DESCRIPTION
Fixes #47.

Now scales according to the main window.

The starting and minimum width of the window is the same, which allows the user to see all buttons, menus and person details. Minimum height of the window is set to about 1 person card's height.