### PR TITLE
Sample data not saved #68

### DIFF
--- a/src/main/java/address/sync/SyncManager.java
+++ b/src/main/java/address/sync/SyncManager.java
@@ -4,6 +4,7 @@ package address.sync;
 import address.events.EventManager;
 import address.events.LocalModelChangedEvent;
 import address.events.NewMirrorDataEvent;
+import address.events.SaveRequestEvent;
 import address.exceptions.FileContainsDuplicatesException;
 import address.model.AddressBook;
 import address.preferences.PreferencesManager;
@@ -70,5 +71,10 @@ public class SyncManager {
     @Subscribe
     public void handleLocalModelChangedEvent(LocalModelChangedEvent lmce) {
         requestExecutor.execute(new CloudUpdateTask(this.cloudSimulator, lmce.personData, lmce.groupData));
+    }
+
+    @Subscribe
+    public void handleSaveRequestEvent(SaveRequestEvent sre) {
+        requestExecutor.execute(new CloudUpdateTask(this.cloudSimulator, sre.personData, sre.groupData));
     }
 }


### PR DESCRIPTION
Hotfixes #68.

Apparently this bug has been there since the very start.
- The only time we wrote to cloud was when we detected a `LocalModelChangeEvent`
- If we save as a different file, technically there wasnt a local mode change, so the cloud isn't updated and the old existing cloud data overwrites the model on the next sync cycle
- saving as a completely new file meant that the mirror file was empty, so the cloud data (nothing) overwrites the sample data

Solution:
- `SyncManager` gets a new handler for `SaveRequestEvent`, so now save requests trigger writes to both local and cloud files 