### PR TITLE
Pending local changes #8

### DIFF
--- a/src/main/java/address/controller/GroupListController.java
+++ b/src/main/java/address/controller/GroupListController.java
@@ -1,6 +1,7 @@
 package address.controller;
 
 import address.model.ContactGroup;
+import address.model.ModelContactGroup;
 import address.model.ModelManager;
 import address.ui.GroupListViewCell;
 import javafx.collections.ObservableList;
@@ -9,13 +10,13 @@ import javafx.scene.control.ListView;
 
 public class GroupListController {
     @FXML
-    private ListView<ContactGroup> groups;
+    private ListView<ModelContactGroup> groups;
 
     @FXML
     private void initialize() {
     }
 
-    public void setGroups(ObservableList<ContactGroup> groupList, MainController mainController,
+    public void setGroups(ObservableList<ModelContactGroup> groupList, MainController mainController,
                           ModelManager modelManager) {
         groups.setItems(groupList);
         groups.setCellFactory(listItem -> new GroupListViewCell(mainController, modelManager));

--- a/src/main/java/address/controller/MainController.java
+++ b/src/main/java/address/controller/MainController.java
@@ -7,6 +7,7 @@ import address.events.FileNameChangedEvent;
 import address.events.FileOpeningExceptionEvent;
 import address.events.FileSavingExceptionEvent;
 import address.model.ContactGroup;
+import address.model.ModelContactGroup;
 import address.model.ModelManager;
 import address.model.Person;
 import address.preferences.PreferencesManager;
@@ -173,7 +174,7 @@ public class MainController {
             PersonEditDialogController controller = loader.getController();
             controller.setDialogStage(dialogStage);
             controller.setInitialPersonData(initialData);
-            controller.setGroupsModel(modelManager.getGroupData(), initialData.getContactGroupsCopy());
+            controller.setGroupsModel(modelManager.getGroups(), initialData.getContactGroupsCopy());
 
             dialogStage.showAndWait();
             if (controller.isOkClicked()) {
@@ -233,7 +234,7 @@ public class MainController {
         }
     }
 
-    public void showGroupList(ObservableList<ContactGroup> groups) {
+    public void showGroupList(ObservableList<ModelContactGroup> groups) {
         final String fxmlResourcePath = FXML_GROUP_LIST;
         try {
             // Load the fxml file and create a new stage for the popup dialog.

--- a/src/main/java/address/controller/PersonOverviewController.java
+++ b/src/main/java/address/controller/PersonOverviewController.java
@@ -4,6 +4,7 @@ import address.events.EventManager;
 import address.events.FilterCommittedEvent;
 import address.exceptions.DuplicatePersonException;
 import address.model.ModelManager;
+import address.model.ModelPerson;
 import address.model.Person;
 import address.parser.ParseException;
 import address.parser.Parser;
@@ -23,7 +24,7 @@ import java.util.Optional;
 public class PersonOverviewController {
 
     @FXML
-    private ListView<Person> personList;
+    private ListView<ModelPerson> personList;
 
     @FXML
     private TextField filterField;
@@ -49,7 +50,7 @@ public class PersonOverviewController {
         this.modelManager = modelManager;
 
         // Add observable list data to the list
-        personList.setItems(modelManager.getFilteredPersons());
+        personList.setItems(modelManager.getFilteredPersonsModel());
         personList.setCellFactory(listView -> new PersonListViewCell());
         personList.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue)
                         -> mainController.loadGithubProfilePage(newValue.getGithubUserName()));

--- a/src/main/java/address/controller/RootLayoutController.java
+++ b/src/main/java/address/controller/RootLayoutController.java
@@ -62,8 +62,8 @@ public class RootLayoutController {
     @FXML
     private void handleSave() {
         final File saveFile = PreferencesManager.getInstance().getPersonFile();
-        EventManager.getInstance().post(new SaveRequestEvent(saveFile, modelManager.getPersons(),
-                                                             modelManager.getGroupData()));
+        EventManager.getInstance().post(new SaveRequestEvent(saveFile, modelManager.getPersonsModel(),
+                                                             modelManager.getGroupModel()));
     }
 
     /**
@@ -81,8 +81,8 @@ public class RootLayoutController {
             file = new File(file.getPath() + ".xml");
         }
         PreferencesManager.getInstance().setPersonFilePath(file);
-        EventManager.getInstance().post(new SaveRequestEvent(file, modelManager.getPersons(),
-                                        modelManager.getGroupData()));
+        EventManager.getInstance().post(new SaveRequestEvent(file, modelManager.getPersonsModel(),
+                                        modelManager.getGroupModel()));
     }
 
     /**
@@ -163,6 +163,6 @@ public class RootLayoutController {
 
     @FXML
     private void handleShowGroups() {
-        mainController.showGroupList(modelManager.getGroupData());
+        mainController.showGroupList(modelManager.getGroupModel());
     }
 }

--- a/src/main/java/address/events/CloudChangeResultReturnedEvent.java
+++ b/src/main/java/address/events/CloudChangeResultReturnedEvent.java
@@ -1,17 +1,20 @@
 package address.events;
 
 import address.model.IModelData;
+import address.model.ModelPerson;
+
+import java.util.List;
 
 public class CloudChangeResultReturnedEvent {
     public enum Result {
         ADD, DELETE, EDIT
     }
 
-    public IModelData affectedData;
+    public List<ModelPerson> affectedData;
     public boolean isSuccessful;
     public Result operationType;
 
-    public CloudChangeResultReturnedEvent(Result operationType, IModelData affectedData, boolean isSuccessful) {
+    public CloudChangeResultReturnedEvent(Result operationType, List<ModelPerson> affectedData, boolean isSuccessful) {
         this.affectedData = affectedData;
         this.isSuccessful = isSuccessful;
         this.operationType = operationType;

--- a/src/main/java/address/events/CloudChangeResultReturnedEvent.java
+++ b/src/main/java/address/events/CloudChangeResultReturnedEvent.java
@@ -1,7 +1,6 @@
 package address.events;
 
-import address.model.IModelData;
-import address.model.ModelPerson;
+import address.model.UniqueData;
 
 import java.util.List;
 
@@ -10,11 +9,11 @@ public class CloudChangeResultReturnedEvent {
         ADD, DELETE, EDIT
     }
 
-    public List<ModelPerson> affectedData;
+    public List<UniqueData> affectedData;
     public boolean isSuccessful;
     public Result operationType;
 
-    public CloudChangeResultReturnedEvent(Result operationType, List<ModelPerson> affectedData, boolean isSuccessful) {
+    public CloudChangeResultReturnedEvent(Result operationType, List<UniqueData> affectedData, boolean isSuccessful) {
         this.affectedData = affectedData;
         this.isSuccessful = isSuccessful;
         this.operationType = operationType;

--- a/src/main/java/address/events/CloudChangeResultReturnedEvent.java
+++ b/src/main/java/address/events/CloudChangeResultReturnedEvent.java
@@ -1,0 +1,19 @@
+package address.events;
+
+import address.model.IModelData;
+
+public class CloudChangeResultReturnedEvent {
+    public enum Result {
+        ADD, DELETE, EDIT
+    }
+
+    public IModelData affectedData;
+    public boolean isSuccessful;
+    public Result operationType;
+
+    public CloudChangeResultReturnedEvent(Result operationType, IModelData affectedData, boolean isSuccessful) {
+        this.affectedData = affectedData;
+        this.isSuccessful = isSuccessful;
+        this.operationType = operationType;
+    }
+}

--- a/src/main/java/address/events/LocalModelChangedEvent.java
+++ b/src/main/java/address/events/LocalModelChangedEvent.java
@@ -1,17 +1,17 @@
 package address.events;
 
-import address.model.ContactGroup;
-import address.model.Person;
+import address.model.ModelContactGroup;
+import address.model.ModelPerson;
 
 import java.util.List;
 
 /** Indicates data in the model has changed*/
 public class LocalModelChangedEvent {
 
-    public List<Person> personData;
-    public List<ContactGroup> groupData;
+    public List<ModelPerson> personData;
+    public List<ModelContactGroup> groupData;
 
-    public LocalModelChangedEvent(List<Person> personData, List<ContactGroup> groupData){
+    public LocalModelChangedEvent(List<ModelPerson> personData, List<ModelContactGroup> groupData){
         this.personData = personData;
         this.groupData = groupData;
     }

--- a/src/main/java/address/events/LocalModelSyncedFromCloudEvent.java
+++ b/src/main/java/address/events/LocalModelSyncedFromCloudEvent.java
@@ -1,6 +1,8 @@
 package address.events;
 
 import address.model.ContactGroup;
+import address.model.ModelContactGroup;
+import address.model.ModelPerson;
 import address.model.Person;
 
 import java.util.List;
@@ -8,11 +10,11 @@ import java.util.List;
 /** Indicates person data in the model was synced with data on the cloud */
 public class LocalModelSyncedFromCloudEvent {
 
-    public List<Person> personData;
+    public List<ModelPerson> personData;
 
-    public List<ContactGroup> groupData;
+    public List<ModelContactGroup> groupData;
 
-    public LocalModelSyncedFromCloudEvent(List<Person> personData, List<ContactGroup> groupData) {
+    public LocalModelSyncedFromCloudEvent(List<ModelPerson> personData, List<ModelContactGroup> groupData) {
         this.personData = personData;
         this.groupData = groupData;
     }

--- a/src/main/java/address/events/SaveRequestEvent.java
+++ b/src/main/java/address/events/SaveRequestEvent.java
@@ -1,6 +1,8 @@
 package address.events;
 
 import address.model.ContactGroup;
+import address.model.ModelContactGroup;
+import address.model.ModelPerson;
 import address.model.Person;
 
 import java.io.File;
@@ -15,10 +17,10 @@ public class SaveRequestEvent {
     public File file;
 
     /** The data to be saved*/
-    public List<Person> personData;
-    public List<ContactGroup> groupData;
+    public List<ModelPerson> personData;
+    public List<ModelContactGroup> groupData;
 
-    public SaveRequestEvent(File file, List<Person> personData, List<ContactGroup> groupData){
+    public SaveRequestEvent(File file, List<ModelPerson> personData, List<ModelContactGroup> groupData){
         this.file = file;
         this.personData = personData;
         this.groupData = groupData;

--- a/src/main/java/address/model/AddressBook.java
+++ b/src/main/java/address/model/AddressBook.java
@@ -1,6 +1,7 @@
 package address.model;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -14,20 +15,25 @@ import javax.xml.bind.annotation.XmlRootElement;
  * 
  * Adapted and modified from Marco Jakob
  */
+
 @XmlRootElement(name = "addressbook")
 public class AddressBook {
 
-    private List<Person> persons = new ArrayList<>(); // so empty lists from file will not make this null
-    private List<ContactGroup> groups = new ArrayList<>(); // ditto
+    private List<Person> persons = new ArrayList<>();
+    private List<ContactGroup> groups = new ArrayList<>();
 
     @XmlElement(name = "persons")
     public List<Person> getPersons() {
-        return persons;
+        return persons.stream()
+                .map(Person::new)
+                .collect(Collectors.toList());
     }
 
     @XmlElement(name = "groups")
     public List<ContactGroup> getGroups() {
-        return groups;
+        return groups.stream()
+                .map(ContactGroup::new)
+                .collect(Collectors.toList());
     }
 
     public void setPersons(List<Person> persons) {

--- a/src/main/java/address/model/IModelData.java
+++ b/src/main/java/address/model/IModelData.java
@@ -1,0 +1,6 @@
+package address.model;
+
+public interface IModelData {
+    boolean isPending();
+    void setPending(boolean isPending);
+}

--- a/src/main/java/address/model/ModelAddressBook.java
+++ b/src/main/java/address/model/ModelAddressBook.java
@@ -1,6 +1,9 @@
 package address.model;
 
 
+import address.events.CloudChangeResultReturnedEvent;
+import com.google.common.eventbus.Subscribe;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
@@ -15,31 +18,29 @@ public class ModelAddressBook extends AddressBook implements IModelData {
     private List<ModelPerson> persons = new ArrayList<>();
     private List<ModelContactGroup> groups = new ArrayList<>();
 
+    public ModelAddressBook() {
+    }
+
     public ModelAddressBook(boolean isPending) {
         this.isPending = isPending;
     }
 
-    /*public ModelAddressBook(AddressBook addressBook, boolean isPending) {
-        super(addressBook);
-        this.isPending = isPending;
-    }*/
-
-
-    @Override
-    @XmlElement(name = "persons")
-    public List<Person> getPersons() {
-        return super.getPersons().stream()
-                .map(Person::new)
-                .collect(Collectors.toList());
+    public void setModelPersons(List<ModelPerson> persons) {
+        this.persons = persons;
     }
 
+    public void setModelGroups(List<ModelContactGroup> groups) {
+        this.groups = groups;
+    }
 
-    @Override
+    @XmlElement(name = "persons")
+    public List<ModelPerson> getModelPersons() {
+        return this.persons;
+    }
+
     @XmlElement(name = "groups")
-    public List<ContactGroup> getGroups() {
-        return groups.stream()
-                .map(ContactGroup::new)
-                .collect(Collectors.toList());
+    public List<ModelContactGroup> getModelGroups() {
+        return this.groups;
     }
 
     @Override
@@ -51,14 +52,6 @@ public class ModelAddressBook extends AddressBook implements IModelData {
     @Override
     public void setPending(boolean isPending) {
         this.isPending = isPending;
-    }
-
-    public void setModelPersons(List<ModelPerson> persons) {
-        this.persons = persons;
-    }
-
-    public void setModelGroups(List<ModelContactGroup> groups) {
-        this.groups = groups;
     }
 
     @Override

--- a/src/main/java/address/model/ModelAddressBook.java
+++ b/src/main/java/address/model/ModelAddressBook.java
@@ -1,0 +1,76 @@
+package address.model;
+
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@XmlRootElement(name = "addressbook")
+public class ModelAddressBook extends AddressBook implements IModelData {
+    private boolean isPending;
+    private List<ModelPerson> persons = new ArrayList<>();
+    private List<ModelContactGroup> groups = new ArrayList<>();
+
+    public ModelAddressBook(boolean isPending) {
+        this.isPending = isPending;
+    }
+
+    /*public ModelAddressBook(AddressBook addressBook, boolean isPending) {
+        super(addressBook);
+        this.isPending = isPending;
+    }*/
+
+
+    @Override
+    @XmlElement(name = "persons")
+    public List<Person> getPersons() {
+        return super.getPersons().stream()
+                .map(Person::new)
+                .collect(Collectors.toList());
+    }
+
+
+    @Override
+    @XmlElement(name = "groups")
+    public List<ContactGroup> getGroups() {
+        return groups.stream()
+                .map(ContactGroup::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @XmlElement(name = "pending")
+    public boolean isPending() {
+        return isPending;
+    }
+
+    @Override
+    public void setPending(boolean isPending) {
+        this.isPending = isPending;
+    }
+
+    public void setModelPersons(List<ModelPerson> persons) {
+        this.persons = persons;
+    }
+
+    public void setModelGroups(List<ModelContactGroup> groups) {
+        this.groups = groups;
+    }
+
+    @Override
+    public boolean containsDuplicates() {
+        final Set<Person> personSet = new HashSet<>();
+        final Set<ContactGroup> groupSet = new HashSet<>();
+        for (Person p : persons) {
+            if (!personSet.add(p)) return true;
+        }
+        for (ContactGroup cg : groups) {
+            if (!groupSet.add(cg)) return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/address/model/ModelContactGroup.java
+++ b/src/main/java/address/model/ModelContactGroup.java
@@ -1,16 +1,24 @@
 package address.model;
 
+import address.events.CloudChangeResultReturnedEvent;
+import address.events.EventManager;
+import com.google.common.eventbus.Subscribe;
+
 public class ModelContactGroup extends ContactGroup implements IModelData {
     private boolean isPending;
 
     public ModelContactGroup(boolean isPending) {
         super();
         this.isPending = isPending;
+
+        EventManager.getInstance().registerHandler(this);
     }
 
     public ModelContactGroup(ContactGroup contactGroup, boolean isPending) {
         super(contactGroup);
         this.isPending = isPending;
+
+        EventManager.getInstance().registerHandler(this);
     }
 
     @Override
@@ -21,5 +29,13 @@ public class ModelContactGroup extends ContactGroup implements IModelData {
     @Override
     public void setPending(boolean isPending) {
         this.isPending = isPending;
+    }
+
+    @Subscribe
+    public void handleCloudChangeResultReturnedEvent(CloudChangeResultReturnedEvent e) {
+        if (e.isSuccessful) {
+            System.out.println("Change for '" + this.getName() + "' successful on cloud. Pending status now false.");
+            if (e.affectedData.contains(this)) this.setPending(false);
+        }
     }
 }

--- a/src/main/java/address/model/ModelContactGroup.java
+++ b/src/main/java/address/model/ModelContactGroup.java
@@ -1,0 +1,25 @@
+package address.model;
+
+public class ModelContactGroup extends ContactGroup implements IModelData {
+    private boolean isPending;
+
+    public ModelContactGroup(boolean isPending) {
+        super();
+        this.isPending = isPending;
+    }
+
+    public ModelContactGroup(ContactGroup contactGroup, boolean isPending) {
+        super(contactGroup);
+        this.isPending = isPending;
+    }
+
+    @Override
+    public boolean isPending() {
+        return isPending;
+    }
+
+    @Override
+    public void setPending(boolean isPending) {
+        this.isPending = isPending;
+    }
+}

--- a/src/main/java/address/model/ModelPerson.java
+++ b/src/main/java/address/model/ModelPerson.java
@@ -1,0 +1,25 @@
+package address.model;
+
+public class ModelPerson extends Person implements IModelData {
+    private boolean isPending;
+
+    public ModelPerson(boolean isPending) {
+        super();
+        this.isPending = isPending;
+    }
+
+    public ModelPerson(Person person, boolean isPending) {
+        super(person);
+        this.isPending = isPending;
+    }
+
+    @Override
+    public boolean isPending() {
+        return isPending;
+    }
+
+    @Override
+    public void setPending(boolean isPending) {
+        this.isPending = isPending;
+    }
+}

--- a/src/main/java/address/model/ModelPerson.java
+++ b/src/main/java/address/model/ModelPerson.java
@@ -1,16 +1,22 @@
 package address.model;
 
+import address.events.CloudChangeResultReturnedEvent;
+import address.events.EventManager;
+import com.google.common.eventbus.Subscribe;
+
 public class ModelPerson extends Person implements IModelData {
     private boolean isPending;
 
     public ModelPerson(boolean isPending) {
         super();
         this.isPending = isPending;
+        EventManager.getInstance().registerHandler(this);
     }
 
     public ModelPerson(Person person, boolean isPending) {
         super(person);
         this.isPending = isPending;
+        EventManager.getInstance().registerHandler(this);
     }
 
     @Override
@@ -21,5 +27,14 @@ public class ModelPerson extends Person implements IModelData {
     @Override
     public void setPending(boolean isPending) {
         this.isPending = isPending;
+    }
+
+    @Subscribe
+    public void handleCloudChangeResultReturnedEvent(CloudChangeResultReturnedEvent e) {
+        if (e.isSuccessful) {
+            System.out.println("Change for '" + this.getFirstName() + " " + this.getLastName() + "'" +
+                    " successful on cloud. Pending status now false.");
+            if (e.affectedData.contains(this)) this.setPending(false);
+        }
     }
 }

--- a/src/main/java/address/storage/StorageManager.java
+++ b/src/main/java/address/storage/StorageManager.java
@@ -34,7 +34,7 @@ public class StorageManager {
     }
 
     @Subscribe
-    private void handleLocalModelChangedEvent(LocalModelChangedEvent lmce){
+    private void handleLocalModelChangedEvent(LocalModelChangedEvent lmce) {
         final File targetFile = PreferencesManager.getInstance().getPersonFile();
         System.out.println("Local data changed, saving to primary data file");
         saveDataToFile(targetFile, lmce.personData, lmce.groupData);

--- a/src/main/java/address/storage/StorageManager.java
+++ b/src/main/java/address/storage/StorageManager.java
@@ -41,14 +41,14 @@ public class StorageManager {
     }
 
     @Subscribe
-    private void handleLocalModelSyncedEvent(LocalModelSyncedFromCloudEvent lmse){
+    private void handleLocalModelSyncedEvent(LocalModelSyncedFromCloudEvent lmse) {
         final File targetFile = PreferencesManager.getInstance().getPersonFile();
         System.out.println("Local data synced, saving to primary data file");
         saveDataToFile(targetFile, lmse.personData, lmse.groupData);
     }
 
     @Subscribe
-    private void handleSaveRequestEvent(SaveRequestEvent se){
+    private void handleSaveRequestEvent(SaveRequestEvent se) {
         saveDataToFile(se.file, se.personData, se.groupData);
     }
 

--- a/src/main/java/address/storage/StorageManager.java
+++ b/src/main/java/address/storage/StorageManager.java
@@ -2,10 +2,7 @@ package address.storage;
 
 import address.events.*;
 import address.exceptions.FileContainsDuplicatesException;
-import address.model.AddressBook;
-import address.model.ContactGroup;
-import address.model.ModelManager;
-import address.model.Person;
+import address.model.*;
 import address.preferences.PreferencesManager;
 import address.util.XmlHelper;
 import com.google.common.eventbus.Subscribe;
@@ -60,9 +57,9 @@ public class StorageManager {
      *
      * @param file
      */
-    public static void saveDataToFile(File file, List<Person> personData, List<ContactGroup> groupData) {
+    public static void saveDataToFile(File file, List<ModelPerson> personData, List<ModelContactGroup> groupData) {
         try {
-            XmlHelper.saveToFile(file, personData, groupData);
+            XmlHelper.saveModelToFile(file, personData, groupData);
         } catch (Exception e) {
             EventManager.getInstance().post(new FileSavingExceptionEvent(e, file));
         }

--- a/src/main/java/address/sync/CloudSimulator.java
+++ b/src/main/java/address/sync/CloudSimulator.java
@@ -57,7 +57,7 @@ public class CloudSimulator {
 
             modifiedData = simulateDataModification(data);
             modifiedData.getPersons().addAll(simulateDataAddition());
-            XmlHelper.saveToFile(cloudFile, modifiedData.getPersons(), modifiedData.getGroups());
+            XmlHelper.saveDataToFile(cloudFile, modifiedData.getPersons(), modifiedData.getGroups());
             TimeUnit.SECONDS.sleep(RANDOM_GENERATOR.nextInt(DELAY_RANGE) + MIN_DELAY_IN_SEC);
         } catch (JAXBException e) {
             e.printStackTrace();
@@ -78,7 +78,7 @@ public class CloudSimulator {
         if (file == null) return;
         List<Person> newPeople = people.stream().map(Person::new).collect(Collectors.toList());
         List<ContactGroup> newGroups = groups.stream().map(ContactGroup::new).collect(Collectors.toList());
-        XmlHelper.saveToFile(file, newPeople, newGroups);
+        XmlHelper.saveDataToFile(file, newPeople, newGroups);
         try {
             TimeUnit.SECONDS.sleep(delay);
         } catch (InterruptedException e) {

--- a/src/main/java/address/sync/SyncManager.java
+++ b/src/main/java/address/sync/SyncManager.java
@@ -7,6 +7,7 @@ import address.events.NewMirrorDataEvent;
 import address.events.SaveRequestEvent;
 import address.exceptions.FileContainsDuplicatesException;
 import address.model.AddressBook;
+import address.model.ModelManager;
 import address.preferences.PreferencesManager;
 import address.sync.task.CloudUpdateTask;
 import com.google.common.eventbus.Subscribe;
@@ -43,7 +44,6 @@ public class SyncManager {
      * in the primary data file. The mirror file should be at the same location
      * as primary file and the name should be '{primary file name}-mirror.xml'.
      * @param interval number of units to wait
-     * @param unit interval order of magnitude
      */
     public void updatePeriodically(long interval) {
         Runnable task = () -> {
@@ -70,7 +70,9 @@ public class SyncManager {
 
     @Subscribe
     public void handleLocalModelChangedEvent(LocalModelChangedEvent lmce) {
-        requestExecutor.execute(new CloudUpdateTask(this.cloudSimulator, lmce.personData, lmce.groupData));
+        requestExecutor.execute(new CloudUpdateTask(this.cloudSimulator,
+                                                    ModelManager.convertToPersons(lmce.personData),
+                                                    ModelManager.convertToGroups(lmce.groupData)));
     }
 
     @Subscribe

--- a/src/main/java/address/sync/SyncManager.java
+++ b/src/main/java/address/sync/SyncManager.java
@@ -70,9 +70,7 @@ public class SyncManager {
 
     @Subscribe
     public void handleLocalModelChangedEvent(LocalModelChangedEvent lmce) {
-        requestExecutor.execute(new CloudUpdateTask(this.cloudSimulator,
-                                                    ModelManager.convertToPersons(lmce.personData),
-                                                    ModelManager.convertToGroups(lmce.groupData)));
+        requestExecutor.execute(new CloudUpdateTask(this.cloudSimulator, lmce.personData, lmce.groupData));
     }
 
     @Subscribe

--- a/src/main/java/address/sync/task/CloudUpdateTask.java
+++ b/src/main/java/address/sync/task/CloudUpdateTask.java
@@ -1,7 +1,8 @@
 package address.sync.task;
 
-import address.model.ContactGroup;
-import address.model.Person;
+import address.events.CloudChangeResultReturnedEvent;
+import address.events.EventManager;
+import address.model.*;
 import address.preferences.PreferencesManager;
 import address.sync.CloudSimulator;
 
@@ -11,10 +12,11 @@ import java.util.List;
 
 public class CloudUpdateTask implements Runnable {
     private final CloudSimulator simulator;
-    private final List<Person> personsData;
-    private final List<ContactGroup> groupsData;
+    private final List<ModelPerson> personsData;
+    private final List<ModelContactGroup> groupsData;
 
-    public CloudUpdateTask(CloudSimulator simulator, List<Person> personsData, List<ContactGroup> groupsData) {
+    public CloudUpdateTask(CloudSimulator simulator, List<ModelPerson> personsData,
+                           List<ModelContactGroup> groupsData) {
         this.simulator = simulator;
         this.personsData = personsData;
         this.groupsData = groupsData;
@@ -25,9 +27,14 @@ public class CloudUpdateTask implements Runnable {
         System.out.println("Requesting changes to the cloud: " + System.nanoTime());
         File mirrorFile = new File(PreferencesManager.getInstance().getPersonFile().toString() + "-mirror.xml");
         try {
-            simulator.requestChangesToCloud(mirrorFile, this.personsData, this.groupsData, 3);
+            simulator.requestChangesToCloud(mirrorFile, ModelManager.convertToPersons(this.personsData),
+                                            ModelManager.convertToGroups(this.groupsData), 3);
+            EventManager.getInstance().post(new CloudChangeResultReturnedEvent(
+                    CloudChangeResultReturnedEvent.Result.EDIT, this.personsData, true));
         } catch (JAXBException e) {
             System.out.println("Error requesting changes to the cloud");
+            EventManager.getInstance().post(new CloudChangeResultReturnedEvent(
+                    CloudChangeResultReturnedEvent.Result.EDIT, this.personsData, false));
         }
     }
 }

--- a/src/main/java/address/sync/task/CloudUpdateTask.java
+++ b/src/main/java/address/sync/task/CloudUpdateTask.java
@@ -8,6 +8,7 @@ import address.sync.CloudSimulator;
 
 import javax.xml.bind.JAXBException;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 
 public class CloudUpdateTask implements Runnable {
@@ -26,15 +27,19 @@ public class CloudUpdateTask implements Runnable {
     public void run() {
         System.out.println("Requesting changes to the cloud: " + System.nanoTime());
         File mirrorFile = new File(PreferencesManager.getInstance().getPersonFile().toString() + "-mirror.xml");
+
+        List<UniqueData> allData = new ArrayList<>();
+        allData.addAll(personsData);
+        allData.addAll(groupsData);
         try {
             simulator.requestChangesToCloud(mirrorFile, ModelManager.convertToPersons(this.personsData),
                                             ModelManager.convertToGroups(this.groupsData), 3);
             EventManager.getInstance().post(new CloudChangeResultReturnedEvent(
-                    CloudChangeResultReturnedEvent.Result.EDIT, this.personsData, true));
+                    CloudChangeResultReturnedEvent.Result.EDIT, allData, true));
         } catch (JAXBException e) {
             System.out.println("Error requesting changes to the cloud");
             EventManager.getInstance().post(new CloudChangeResultReturnedEvent(
-                    CloudChangeResultReturnedEvent.Result.EDIT, this.personsData, false));
+                    CloudChangeResultReturnedEvent.Result.EDIT, allData, false));
         }
     }
 }

--- a/src/main/java/address/ui/GroupListViewCell.java
+++ b/src/main/java/address/ui/GroupListViewCell.java
@@ -3,10 +3,11 @@ package address.ui;
 import address.controller.GroupCardController;
 import address.controller.MainController;
 import address.model.ContactGroup;
+import address.model.ModelContactGroup;
 import address.model.ModelManager;
 import javafx.scene.control.ListCell;
 
-public class GroupListViewCell extends ListCell<ContactGroup> {
+public class GroupListViewCell extends ListCell<ModelContactGroup> {
     MainController mainController;
     ModelManager modelManager;
 
@@ -16,7 +17,7 @@ public class GroupListViewCell extends ListCell<ContactGroup> {
     }
 
     @Override
-    public void updateItem(ContactGroup group, boolean empty) {
+    public void updateItem(ModelContactGroup group, boolean empty) {
         super.updateItem(group, empty);
         if (empty || group == null) {
             setGraphic(null);

--- a/src/main/java/address/ui/PersonListViewCell.java
+++ b/src/main/java/address/ui/PersonListViewCell.java
@@ -1,13 +1,14 @@
 package address.ui;
 
 import address.controller.PersonCardController;
+import address.model.ModelPerson;
 import address.model.Person;
 import javafx.scene.control.ListCell;
 
-public class PersonListViewCell extends ListCell<Person> {
+public class PersonListViewCell extends ListCell<ModelPerson> {
 
     @Override
-    public void updateItem(Person person, boolean empty) {
+    public void updateItem(ModelPerson person, boolean empty) {
         super.updateItem(person, empty);
         if (empty || person == null) {
             setGraphic(null);

--- a/src/main/java/address/util/XmlHelper.java
+++ b/src/main/java/address/util/XmlHelper.java
@@ -1,8 +1,6 @@
 package address.util;
 
-import address.model.AddressBook;
-import address.model.ContactGroup;
-import address.model.Person;
+import address.model.*;
 import address.updater.model.UpdateData;
 
 import javax.xml.bind.JAXBContext;
@@ -25,7 +23,22 @@ public class XmlHelper {
         return ((AddressBook) um.unmarshal(file));
     }
 
-    public static void saveToFile(File file, List<Person> personData, List<ContactGroup> groupData)
+    public static void saveModelToFile(File file, List<ModelPerson> personData, List<ModelContactGroup> groupData)
+            throws JAXBException {
+        JAXBContext context = JAXBContext.newInstance(AddressBook.class);
+        Marshaller m = context.createMarshaller();
+        m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+
+        // Wrapping our person data.
+        ModelAddressBook wrapper = new ModelAddressBook(false);
+        wrapper.setModelPersons(personData);
+        wrapper.setModelGroups(groupData);
+
+        // Marshalling and saving XML to the file.
+        m.marshal(wrapper, file);
+    }
+
+    public static void saveDataToFile(File file, List<Person> personData, List<ContactGroup> groupData)
             throws JAXBException {
         JAXBContext context = JAXBContext.newInstance(AddressBook.class);
         Marshaller m = context.createMarshaller();

--- a/src/main/java/address/util/XmlHelper.java
+++ b/src/main/java/address/util/XmlHelper.java
@@ -11,7 +11,7 @@ import java.io.File;
 import java.util.List;
 
 /**
- * Helps with reading from and writing to the XML file.
+ * Helps with reading from and writing to XML files.
  */
 public class XmlHelper {
 
@@ -25,7 +25,7 @@ public class XmlHelper {
 
     public static void saveModelToFile(File file, List<ModelPerson> personData, List<ModelContactGroup> groupData)
             throws JAXBException {
-        JAXBContext context = JAXBContext.newInstance(AddressBook.class);
+        JAXBContext context = JAXBContext.newInstance(ModelAddressBook.class);
         Marshaller m = context.createMarshaller();
         m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 


### PR DESCRIPTION
Fixes #8

`Person`, `ContactGroup` and `AddressBook` now has its `Model` version which implements a boolean status variable `isPending`. Unless necessary, components such as `EditDialog` should not have to deal with the `Model` version of it, and thus the data should be cast to its non-`Model` version before being passed to such components. Examples of components which may have to deal with the `Model` version may include the `PersonOverview` since we wish to have real-time updates of the pending status (to reflect if the add/edit/delete is successful).

This does not fully implement the desired changes since all data (except the AddressBook wrapper) is passed to the cloud for processing. <s>Moreover, for</s> now, <s>only</s> the list of `Person` **and list of `Group` are**<s>is</s> sent in the success 'notification'. This behaviour will thus affect all data here i.e. every `ModelPerson` data is made to !isPending even when only 1 of it is modified, which should not be the case.

When using GitHub's API, usually only the affected data is embedded within the request.