### PR TITLE
Clean up storage manager #175

### DIFF
--- a/src/main/java/address/MainApp.java
+++ b/src/main/java/address/MainApp.java
@@ -62,7 +62,7 @@ public class MainApp extends Application {
     protected void setupComponents() {
         config = getConfig();
         modelManager = new ModelManager();
-        storageManager = new StorageManager(modelManager);
+        storageManager = new StorageManager(modelManager, PrefsManager.getInstance(), EventManager.getInstance());
         mainController = new MainController(this, modelManager, config);
         syncManager = new SyncManager();
 

--- a/src/main/java/address/model/AddressBook.java
+++ b/src/main/java/address/model/AddressBook.java
@@ -22,6 +22,15 @@ public class AddressBook {
     private List<Person> persons = new ArrayList<>();
     private List<Tag> tags = new ArrayList<>();
 
+    //TODO: remove this empty constructor
+    public AddressBook (){
+    }
+
+    public AddressBook (List<Person> persons, List<Tag> tags){
+        this.persons = persons;
+        this.tags = tags;
+    }
+
     @XmlElement(name = "persons")
     public List<Person> getPersons() {
         return persons;

--- a/src/main/java/address/storage/XmlFileStorage.java
+++ b/src/main/java/address/storage/XmlFileStorage.java
@@ -1,0 +1,29 @@
+package address.storage;
+
+import address.model.AddressBook;
+import address.util.XmlFileHelper;
+
+import javax.xml.bind.JAXBException;
+import java.io.File;
+
+/**
+ * Stores addressbook data in an XML file
+ */
+public class XmlFileStorage {
+    /**
+     * Saves the given addressbook data to the specified file.
+     */
+    public static void saveDataToFile(File file, AddressBook addressBook) throws JAXBException {
+        assert file != null;
+        XmlFileHelper.saveDataToFile(file, addressBook);
+    }
+
+    /**
+     * Returns address book in the file or an empty address book
+     */
+    public static AddressBook loadDataFromSaveFile(File file) throws JAXBException {
+        assert file != null;
+        return XmlFileHelper.getDataFromFile(file, AddressBook.class);
+    }
+
+}

--- a/src/main/java/address/sync/CloudSimulator.java
+++ b/src/main/java/address/sync/CloudSimulator.java
@@ -468,7 +468,7 @@ public class CloudSimulator implements ICloudSimulator {
         File cloudFile = getCloudDataFilePath(addressBookName);
         System.out.println("Reading from cloudFile: " + cloudFile.canRead());
         try {
-            CloudAddressBook cloudAddressBook = XmlFileHelper.getCloudDataFromFile(cloudFile);
+            CloudAddressBook cloudAddressBook = XmlFileHelper.getDataFromFile(cloudFile, CloudAddressBook.class);
             return cloudAddressBook;
         } catch (JAXBException e) {
             System.out.println("Error reading from cloud file.");
@@ -484,7 +484,7 @@ public class CloudSimulator implements ICloudSimulator {
         File cloudFile = getCloudDataFilePath(addressBookName);
         System.out.println("Writing to cloudFile: " + cloudFile.canRead());
         try {
-            XmlFileHelper.saveCloudDataToFile(cloudFile, cloudAddressBook);
+            XmlFileHelper.saveDataToFile(cloudFile, cloudAddressBook);
         } catch (JAXBException e) {
             System.out.println("Error writing to cloud file.");
             throw e;

--- a/src/main/java/address/util/XmlFileHelper.java
+++ b/src/main/java/address/util/XmlFileHelper.java
@@ -1,95 +1,35 @@
 package address.util;
 
-import address.model.*;
-import address.model.datatypes.Person;
-import address.model.datatypes.Tag;
-import address.sync.model.CloudAddressBook;
-import address.sync.model.CloudTag;
-import address.sync.model.CloudPerson;
-import address.updater.model.UpdateData;
-
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 import java.io.File;
-import java.util.List;
 
 /**
  * Helps with reading from and writing to XML files.
  */
 public class XmlFileHelper {
 
-    public static CloudAddressBook getCloudDataFromFile(File file) throws JAXBException {
-        JAXBContext context = JAXBContext.newInstance(CloudAddressBook.class);
+    /**
+     * Returns the xml data in the file as an object of the specified type
+     */
+    public static <T> T getDataFromFile(File file, Class<T> classToConvert) throws JAXBException {
+        JAXBContext context = JAXBContext.newInstance(classToConvert);
         Unmarshaller um = context.createUnmarshaller();
 
-        // Reading XML from the file and unmarshalling.
-        return ((CloudAddressBook) um.unmarshal(file));
+        return ((T) um.unmarshal(file));
     }
 
-    public static void saveCloudDataToFile(File file, CloudAddressBook cloudAddressBook) throws JAXBException {
-        JAXBContext context = JAXBContext.newInstance(CloudAddressBook.class);
+    /**
+     * Saves the data in the file in xml format
+     */
+    public static <T> void saveDataToFile(File file, T data) throws JAXBException {
+        JAXBContext context = JAXBContext.newInstance(data.getClass());
         Marshaller m = context.createMarshaller();
         m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 
-        // Marshalling and saving XML to the file.
-        m.marshal(cloudAddressBook, file);
+        m.marshal(data, file);
     }
 
-    public static AddressBook getDataFromFile(File file) throws JAXBException {
-        JAXBContext context = JAXBContext.newInstance(AddressBook.class);
-        Unmarshaller um = context.createUnmarshaller();
-
-        // Reading XML from the file and unmarshalling.
-        return ((AddressBook) um.unmarshal(file));
-    }
-
-    public static void saveModelToFile(File file, List<Person> personData, List<Tag> tagData)
-            throws JAXBException {
-        JAXBContext context = JAXBContext.newInstance(AddressBook.class);
-        Marshaller m = context.createMarshaller();
-        m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-
-        // Wrapping our person data.
-        AddressBook wrapper = new AddressBook();
-        wrapper.setPersons(personData);
-        wrapper.setTags(tagData);
-
-        // Marshalling and saving XML to the file.
-        m.marshal(wrapper, file);
-    }
-
-    public static void saveDataToFile(File file, List<Person> personData, List<Tag> tagData)
-            throws JAXBException {
-        JAXBContext context = JAXBContext.newInstance(AddressBook.class);
-        Marshaller m = context.createMarshaller();
-        m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-
-        // Wrapping our person data.
-        AddressBook wrapper = new AddressBook();
-        wrapper.setPersons(personData);
-        wrapper.setTags(tagData);
-
-        // Marshalling and saving XML to the file.
-        m.marshal(wrapper, file);
-    }
-
-    public static UpdateData getUpdateDataFromFile(File file) throws JAXBException {
-        JAXBContext context = JAXBContext.newInstance(UpdateData.class);
-        Unmarshaller um = context.createUnmarshaller();
-
-        // Reading XML from the file and unmarshalling.
-        return ((UpdateData) um.unmarshal(file));
-    }
-
-    public static void saveUpdateDataToFile(File file, UpdateData updateData)
-            throws JAXBException {
-        JAXBContext context = JAXBContext.newInstance(UpdateData.class);
-        Marshaller m = context.createMarshaller();
-        m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-
-        // Marshalling and saving XML to the file.
-        m.marshal(updateData, file);
-    }
 }


### PR DESCRIPTION
* Made dependencies injectable
* Separated 'Manager' tasks from other tasks by adding a `XmlFileStorage` class
* Trimmed `XmlFileHelper` class
* Stopped StorageManager from raising `SaveRequestEvent` (this class should respond to the event rather than raise it). Likely to break something somewhere, but hopefully it will get sorted out later.