### PR TITLE
Fix Installer error on Windows due to URL path reading error

### DIFF
--- a/src/main/java/installer/Installer.java
+++ b/src/main/java/installer/Installer.java
@@ -161,7 +161,7 @@ public class Installer extends Application {
             return;
         }
 
-        String jxBrowserFilename = Paths.get(downloadLink.toString()).getFileName().toString();
+        String jxBrowserFilename = Paths.get(downloadLink.getPath()).getFileName().toString();
         File jxbrowserFile = Paths.get("lib", jxBrowserFilename).toFile();
 
         try {


### PR DESCRIPTION
Installer on Windows fails with no warning because of conversion of URL to path that fails on Windows but not on Mac.

Using alternative URL to path conversion to make it work on Windows.