### PR TITLE
Remove EventManager dependency from sub classes of ComponentManager

### DIFF
--- a/src/main/java/address/MainApp.java
+++ b/src/main/java/address/MainApp.java
@@ -62,11 +62,11 @@ public class MainApp extends Application {
     protected void setupComponents() {
         config = getConfig();
         modelManager = new ModelManager();
-        storageManager = new StorageManager(modelManager, PrefsManager.getInstance(), EventManager.getInstance());
+        storageManager = new StorageManager(modelManager, PrefsManager.getInstance());
         mainController = new MainController(this, modelManager, config);
         syncManager = new SyncManager();
 
-        shortcutsManager = new ShortcutsManager(EventManager.getInstance());
+        shortcutsManager = new ShortcutsManager();
 
         updateManager = new UpdateManager();
         alertMissingDependencies();

--- a/src/main/java/address/main/ComponentManager.java
+++ b/src/main/java/address/main/ComponentManager.java
@@ -9,9 +9,24 @@ import address.events.EventManager;
 public class ComponentManager {
     protected EventManager eventManager;
 
+    /**
+     * Uses default {@link EventManager}
+     */
+    public ComponentManager(){
+        this(EventManager.getInstance());
+    }
+
     public ComponentManager(EventManager eventManager){
         this.eventManager = eventManager;
         eventManager.registerHandler(this);
+    }
+
+    /**
+     * Injects the {@link EventManager} dependency
+     * @param eventManager
+     */
+    public void setEventManager(EventManager eventManager) {
+        this.eventManager = eventManager;
     }
 
     protected void raise(BaseEvent event){

--- a/src/main/java/address/shortcuts/ShortcutsManager.java
+++ b/src/main/java/address/shortcuts/ShortcutsManager.java
@@ -22,8 +22,8 @@ public class ShortcutsManager extends ComponentManager{
     public static Bindings BINDINGS;
 
 
-    public ShortcutsManager(EventManager eventsManager) {
-        super(eventsManager);
+    public ShortcutsManager() {
+        super();
         BINDINGS = new Bindings();
         registerGlobalHotkeys(BINDINGS.getHotkeys());
     }

--- a/src/main/java/address/storage/StorageManager.java
+++ b/src/main/java/address/storage/StorageManager.java
@@ -22,10 +22,9 @@ public class StorageManager extends ComponentManager{
     private PrefsManager prefsManager;
 
     public StorageManager(ModelManager modelManager,
-                          PrefsManager prefsManager,
-                          EventManager eventManager){
+                          PrefsManager prefsManager){
 
-        super(eventManager);
+        super();
         this.modelManager = modelManager;
         this.prefsManager = prefsManager;
     }

--- a/src/test/java/address/unittests/storage/StorageManagerTest.java
+++ b/src/test/java/address/unittests/storage/StorageManagerTest.java
@@ -43,7 +43,8 @@ public class StorageManagerTest {
         modelManagerMock = Mockito.mock(ModelManager.class);
         eventManagerMock = Mockito.mock(EventManager.class);
         prefsManagerMock = Mockito.mock(PrefsManager.class);
-        storageManager = new StorageManager(modelManagerMock, prefsManagerMock, eventManagerMock);
+        storageManager = new StorageManager(modelManagerMock, prefsManagerMock);
+        storageManager.setEventManager(eventManagerMock);
 
         // This spy will be used to mock only one method of the object under test
         storageManagerSpy = spy(storageManager);


### PR DESCRIPTION
Child classes don't have to refer to `EventManger` now. The dependency is managed my the parent class `ComponentManager`