### PR TITLE
Abstracts a GlobalHotKeyProvider as an adapter for jkeymaster library

### DIFF
--- a/src/main/java/address/keybindings/GlobalHotkeyProvider.java
+++ b/src/main/java/address/keybindings/GlobalHotkeyProvider.java
@@ -1,0 +1,58 @@
+package address.keybindings;
+
+import address.events.EventManager;
+import address.events.GlobalHotkeyEvent;
+import address.events.KeyBindingEvent;
+import com.google.common.eventbus.Subscribe;
+import com.tulskiy.keymaster.common.Provider;
+
+import java.util.List;
+
+/**
+ * An adapter that wraps around jKeyMaster hotkey provider.
+ * Detects global hotkeys and raises an {@link KeyBindingEvent}
+ */
+public class GlobalHotkeyProvider {
+    /** Provider for global hotkeys */
+    private final Provider provider = Provider.getCurrentProvider(false);
+    private EventManager eventManager;
+
+    /**
+     * Creates an instance and init the global hotkeys.
+     * @param eventManager
+     */
+    GlobalHotkeyProvider(EventManager eventManager){
+        this.eventManager = eventManager;
+        eventManager.registerHandler(this);
+    }
+
+    /**
+     * Registers a {@link GlobalHotkeyEvent} with jKeymaster for each global hotkey
+     * @param hotkeys
+     */
+    void registerGlobalHotkeys(List<GlobalHotkey> hotkeys) {
+        for (GlobalHotkey hk: hotkeys){
+            provider.register(hk.getKeyStroke(),
+                    (hotkey) -> eventManager.post(new GlobalHotkeyEvent(hk.keyCombination)));
+        }
+    }
+
+    /**
+     * Swallows the {@link GlobalHotkeyEvent} raised by jKeyMaster and
+     * raises the corresponding {@link KeyBindingEvent}
+     * @param globalHotkeyEvent
+     */
+    @Subscribe
+    public void handleGlobalHotkeyEvent(GlobalHotkeyEvent globalHotkeyEvent){
+        eventManager.post(globalHotkeyEvent.keyBindingEvent);
+    }
+
+
+    /**
+     * Resets global hotkeys
+     */
+    public void clear() {
+        provider.reset();
+        provider.stop();
+    }
+}

--- a/src/main/java/address/keybindings/KeyBindingsManager.java
+++ b/src/main/java/address/keybindings/KeyBindingsManager.java
@@ -1,15 +1,12 @@
 package address.keybindings;
 
 import address.events.BaseEvent;
-import address.events.GlobalHotkeyEvent;
 import address.events.KeyBindingEvent;
 import address.main.ComponentManager;
 import com.google.common.eventbus.Subscribe;
-import com.tulskiy.keymaster.common.Provider;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -19,39 +16,21 @@ public class KeyBindingsManager extends ComponentManager{
 
     private static final Logger logger = LogManager.getLogger(KeyBindingsManager.class);
 
-    /** Provider for global hotkeys */
-    private final Provider provider = Provider.getCurrentProvider(false);
+    /** Manages global hotkey detection */
+    private GlobalHotkeyProvider hotkeyProvider = new GlobalHotkeyProvider(eventManager);
 
     /** To keep track of the previous keyboard event, to match for key sequences */
     private KeyBindingEvent previousKeyEvent = null;
 
     public static Bindings BINDINGS;
 
-
+    /**
+     * Creates an instance and initializes key bindings (i.e. ready for detection and handling)
+     */
     public KeyBindingsManager() {
         super();
         BINDINGS = new Bindings();
-        registerGlobalHotkeys(BINDINGS.getHotkeys());
-    }
-
-    /**
-     * Registers a {@link GlobalHotkeyEvent} with jKeymaster for each global hotkey
-     * @param hotkeys
-     */
-    private void registerGlobalHotkeys(List<GlobalHotkey> hotkeys) {
-        for (GlobalHotkey hk: hotkeys){
-            provider.register(hk.getKeyStroke(), (hotkey) -> raise(new GlobalHotkeyEvent(hk.keyCombination)));
-        }
-    }
-
-    /**
-     * Swallows the {@link GlobalHotkeyEvent} raised by jKeyMaster and
-     * raises the corresponding {@link KeyBindingEvent}
-     * @param globalHotkeyEvent
-     */
-    @Subscribe
-    public void handleGlobalHotkeyEvent(GlobalHotkeyEvent globalHotkeyEvent){
-        raise(globalHotkeyEvent.keyBindingEvent);
+        hotkeyProvider.registerGlobalHotkeys(BINDINGS.getHotkeys());
     }
 
     @Subscribe
@@ -78,7 +57,6 @@ public class KeyBindingsManager extends ComponentManager{
      * Resets global hotkeys
      */
     public void clear() {
-        provider.reset();
-        provider.stop();
+        hotkeyProvider.clear();
     }
 }


### PR DESCRIPTION
`GlobalHotKeyProvider ` hides the conversion between jkeymaster hotkey handling and ours and works as an adapter