### PR TITLE
Corrected browser test on Mac

### DIFF
--- a/src/test/java/address/util/JavafxThreadingRule.java
+++ b/src/test/java/address/util/JavafxThreadingRule.java
@@ -1,9 +1,13 @@
 package address.util;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import javax.swing.SwingUtilities;
 
+import address.browser.BrowserManager;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
 
@@ -31,6 +35,17 @@ public class JavafxThreadingRule implements TestRule {
      * Flag for setting up the JavaFX, we only need to do this once for all tests.
      */
     private static boolean jfxIsSetup;
+
+    public JavafxThreadingRule() {
+        ExecutorService executor = Executors.newFixedThreadPool(1);
+        Runnable task = () -> BrowserManager.initializeBrowser();
+        Future<?> future = executor.submit(task);
+        try {
+            future.get();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
 
     @Override
     public Statement apply(Statement statement, Description description) {


### PR DESCRIPTION
1 test fails on Mac due to uninitialised JxBrowser.