### PR TITLE
Made gui tests more configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ lib/*
 /*.xml
 update/
 src/main/resources/updater/jarUpdater.jar
+src/test/data/sandbox/

--- a/src/main/java/address/controller/MainController.java
+++ b/src/main/java/address/controller/MainController.java
@@ -114,6 +114,7 @@ public class MainController {
             logger.warn("Error initializing root layout: {}", e);
             showAlertDialogAndWait(AlertType.ERROR, "FXML Load Error", "Cannot load fxml root layout.",
                                    "IOException when trying to load " + fxmlResourcePath);
+            //TODO: this dialog doesn't show up
         }
     }
 
@@ -425,4 +426,8 @@ public class MainController {
         primaryStage.setIconified(false);
     }
 
+    public void stop() {
+        getPrimaryStage().hide();
+        releaseResourcesForAppTermination();
+    }
 }

--- a/src/main/java/address/controller/RootLayoutController.java
+++ b/src/main/java/address/controller/RootLayoutController.java
@@ -79,7 +79,7 @@ public class RootLayoutController {
 
     private void updateSaveLocationDisplay() {
         saveLocText.setText(SAVE_LOC_TEXT_PREFIX + (PrefsManager.getInstance().isSaveLocationSet() ?
-                PrefsManager.getInstance().getSaveLocation().getName() : LOC_TEXT_NOT_SET));
+                PrefsManager.getInstance().getPrefs().getSaveLocation().getName() : LOC_TEXT_NOT_SET));
     }
 
     /**
@@ -92,7 +92,7 @@ public class RootLayoutController {
         final FileChooser fileChooser = new FileChooser();
 
         fileChooser.getExtensionFilters().add(extFilter);
-        final File currentFile = PrefsManager.getInstance().getSaveLocation();
+        final File currentFile = PrefsManager.getInstance().getPrefs().getSaveLocation();
         fileChooser.setInitialDirectory(currentFile.getParentFile());
         return fileChooser;
     }
@@ -127,7 +127,7 @@ public class RootLayoutController {
      */
     @FXML
     private void handleSave() {
-        final File saveFile = PrefsManager.getInstance().getSaveLocation();
+        final File saveFile = PrefsManager.getInstance().getPrefs().getSaveLocation();
         logger.debug("Requesting save to: {}.", saveFile);
         EventManager.getInstance().post(new SaveRequestEvent(saveFile, modelManager.backingPersonList(),
                                                              modelManager.getTagList()));

--- a/src/main/java/address/keybindings/KeyBindingsManager.java
+++ b/src/main/java/address/keybindings/KeyBindingsManager.java
@@ -56,7 +56,7 @@ public class KeyBindingsManager extends ComponentManager{
     /**
      * Resets global hotkeys
      */
-    public void clear() {
+    public void stop() {
         hotkeyProvider.clear();
     }
 

--- a/src/main/java/address/model/ModelManager.java
+++ b/src/main/java/address/model/ModelManager.java
@@ -74,22 +74,7 @@ public class ModelManager implements ReadOnlyAddressBook, ReadOnlyViewableAddres
     }
 
     public synchronized void resetWithSampleData() throws DuplicateDataException {
-        final Person[] samplePersonData = {
-            new Person("Hans", "Muster"),
-            new Person("Ruth", "Mueller"),
-            new Person("Heinz", "Kurz"),
-            new Person("Cornelia", "Meier"),
-            new Person("Werner", "Meyer"),
-            new Person("Lydia", "Kunz"),
-            new Person("Anna", "Best"),
-            new Person("Stefan", "Meier"),
-            new Person("Martin", "Mueller")
-        };
-        final Tag[] sampleTagData = {
-            new Tag("relatives"),
-            new Tag("friends")
-        };
-        resetData(new AddressBook(Arrays.asList(samplePersonData), Arrays.asList(sampleTagData)));
+        resetData(AddressBook.generateSampleData());
     }
 
     /**

--- a/src/main/java/address/model/datatypes/AddressBook.java
+++ b/src/main/java/address/model/datatypes/AddressBook.java
@@ -131,4 +131,23 @@ public class AddressBook implements ReadOnlyAddressBook {
     public UnmodifiableObservableList<Tag> getTagsAsReadOnlyObservableList() {
         return new UnmodifiableObservableList<>(tags);
     }
+
+    public static AddressBook generateSampleData(){
+        final Person[] samplePersonData = {
+                new Person("Hans", "Muster"),
+                new Person("Ruth", "Mueller"),
+                new Person("Heinz", "Kurz"),
+                new Person("Cornelia", "Meier"),
+                new Person("Werner", "Meyer"),
+                new Person("Lydia", "Kunz"),
+                new Person("Anna", "Best"),
+                new Person("Stefan", "Meier"),
+                new Person("Martin", "Mueller")
+        };
+        final Tag[] sampleTagData = {
+                new Tag("relatives"),
+                new Tag("friends")
+        };
+        return new AddressBook(Arrays.asList(samplePersonData), Arrays.asList(sampleTagData));
+    }
 }

--- a/src/main/java/address/prefs/PrefsManager.java
+++ b/src/main/java/address/prefs/PrefsManager.java
@@ -14,10 +14,11 @@ public class PrefsManager {
 
     public static final String SAVE_LOC_PREF_KEY = "save-location";
 
-    public static final String DEFAULT_TEMP_FILE_PATH = ".$TEMP_ADDRESS_BOOK";
 
     private static PrefsManager instance;
-    private static Preferences userPrefs = Preferences.userNodeForPackage(PrefsManager.class);
+    private static Preferences prefStorage = Preferences.userNodeForPackage(PrefsManager.class);
+
+    private UserPrefs prefs;
 
     public static PrefsManager getInstance(){
         if (instance == null){
@@ -26,18 +27,17 @@ public class PrefsManager {
         return instance;
     }
 
-    private PrefsManager() {}
+    private PrefsManager() {
+        prefs = new UserPrefs();
+        prefs.saveLocation = prefStorage.get(SAVE_LOC_PREF_KEY, null);
+    }
 
-    /**
-     * @return the current save file preference or the default temp file if there is no recorded preference.
-     */
-    public File getSaveLocation() {
-        final String filePath = userPrefs.get(SAVE_LOC_PREF_KEY, null);
-        return filePath == null ? new File(DEFAULT_TEMP_FILE_PATH) : new File(filePath);
+    public UserPrefs getPrefs(){
+        return prefs;
     }
 
     public boolean isSaveLocationSet() {
-        return userPrefs.get(SAVE_LOC_PREF_KEY, null) != null;
+        return prefStorage.get(SAVE_LOC_PREF_KEY, null) != null;
     }
 
     /**
@@ -47,15 +47,17 @@ public class PrefsManager {
      */
     public void setSaveLocation(File save) {
         assert save != null;
-        userPrefs.put(SAVE_LOC_PREF_KEY, save.getPath());
-        EventManager.getInstance().post(new SaveLocationChangedEvent(getSaveLocation()));
+        prefStorage.put(SAVE_LOC_PREF_KEY, save.getPath());
+        prefs.saveLocation = save.getPath();
+        EventManager.getInstance().post(new SaveLocationChangedEvent(prefs.getSaveLocation()));
     }
 
     /**
      * Clears the current preferred save file path.
      */
     public void clearSaveLocation() {
-        userPrefs.remove(SAVE_LOC_PREF_KEY);
+        prefStorage.remove(SAVE_LOC_PREF_KEY);
+        prefs.saveLocation = null;
         EventManager.getInstance().post(new SaveLocationChangedEvent(null));
     }
 }

--- a/src/main/java/address/prefs/UserPrefs.java
+++ b/src/main/java/address/prefs/UserPrefs.java
@@ -1,0 +1,24 @@
+package address.prefs;
+
+import java.io.File;
+
+/**
+ * Represents User's preferences.
+ */
+public class UserPrefs {
+    public static final String DEFAULT_TEMP_FILE_PATH = ".$TEMP_ADDRESS_BOOK";
+
+
+    /**
+     * Full path (including file name) of the data file to be used for local storage
+     */
+
+    protected String saveLocation;
+
+    /**
+     * @return the current save file location or the default temp file location if there is no recorded preference.
+     */
+    public File getSaveLocation() {
+        return saveLocation == null ? new File(DEFAULT_TEMP_FILE_PATH) : new File(saveLocation);
+    }
+}

--- a/src/main/java/address/sync/SyncManager.java
+++ b/src/main/java/address/sync/SyncManager.java
@@ -60,7 +60,7 @@ public class SyncManager {
      *
      * @param interval should be a positive integer
      */
-    public void startSyncingData(long interval) {
+    public void start(long interval) {
         if (interval <= 0) {
             logger.warn("Update interval specified is not positive: {}", interval);
             return;

--- a/src/main/java/address/updater/UpdateManager.java
+++ b/src/main/java/address/updater/UpdateManager.java
@@ -65,7 +65,7 @@ public class UpdateManager {
         return dependencyTracker.getMissingDependencies();
     }
 
-    public void run() {
+    public void start() {
         pool.execute(backupManager::cleanupBackups);
         pool.execute(this::checkForUpdate);
     }
@@ -344,5 +344,9 @@ public class UpdateManager {
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    public void stop() {
+        applyUpdate();
     }
 }

--- a/src/main/java/address/util/FileUtil.java
+++ b/src/main/java/address/util/FileUtil.java
@@ -25,10 +25,10 @@ public class FileUtil {
         return dir.exists() && dir.isDirectory();
     }
 
-    public static boolean isDirExists(String dirpath) {
-        File dir = new File(dirpath);
-
-        return isDirExists(dir);
+    public static void createIfMissing(File file) throws IOException {
+        if(!isFileExists(file)){
+            createFile(file);
+        }
     }
 
     /**

--- a/src/test/java/address/TestApp.java
+++ b/src/test/java/address/TestApp.java
@@ -1,17 +1,33 @@
 package address;
 
 
+import address.prefs.PrefsManager;
 import address.util.Config;
-import com.google.common.util.concurrent.SettableFuture;
-import javafx.stage.Stage;
+import address.util.TestUtil;
+
+import java.io.File;
 
 public class TestApp extends MainApp {
 
+    String saveLocationForTesting = TestUtil.appendToSandboxPath("sampleData.xml");
+
+    public TestApp(){
+        super();
+        stageTestScenario();
+    }
+
+    protected void stageTestScenario() {
+        TestUtil.createDataFileWithSampleData(saveLocationForTesting);
+    }
+
     @Override
-    protected Config getConfig() {
-        Config testConfig = new Config();
-        testConfig.appTitle = "Test App";
-        return testConfig;
+    protected void initConfig() {
+        Config.getConfig().appTitle = "Test App";
+    }
+
+    @Override
+    protected void initPrefs() {
+        PrefsManager.getInstance().setSaveLocation(new File(saveLocationForTesting));
     }
 
     public static void main(String[] args) {

--- a/src/test/java/address/guitests/GuiTestBase.java
+++ b/src/test/java/address/guitests/GuiTestBase.java
@@ -25,10 +25,6 @@ public class GuiTestBase extends FxRobot {
     public void setup() throws Exception {
         EventManager.clearSubscribers();
         FxToolkit.setupApplication(TestApp.class);
-
-        // since we cannot handle custom test data files
-        // we assume that the default data file exists, and we append data to it
-        clickOn("File").clickOn("Reset with Sample Data");
     }
 
     @After

--- a/src/test/java/address/guitests/PersonEditDialogTest.java
+++ b/src/test/java/address/guitests/PersonEditDialogTest.java
@@ -12,10 +12,14 @@ public class PersonEditDialogTest extends GuiTestBase {
     @Test
     public void testUpdatePerson() {
         // TODO: find out why context menu does not appear in headless tests
-        clickOn("Hans").push(KeyCode.E).targetWindow("Edit Person")
+        // TODO: This does not work if the person is not visible (i.e. too far down the list)
+        String nameOfPersonToEdit = "Lydia";
+        sleep(1000); //TODO: remove this (at the moment, fails if this delay is removed
+        clickOn(nameOfPersonToEdit).push(KeyCode.E).targetWindow("Edit Person")
                 .clickOn("#cityField").write("My City").clickOn("OK");
 
-        clickOn("Hans").push(KeyCode.E).targetWindow("Edit Person");
+        sleep(1000);//TODO: remove this
+        clickOn(nameOfPersonToEdit).push(KeyCode.E).targetWindow("Edit Person");
 
         verifyThat("#cityField", hasText("My City"));
     }

--- a/src/test/java/address/unittests/storage/StorageManagerTest.java
+++ b/src/test/java/address/unittests/storage/StorageManagerTest.java
@@ -4,9 +4,10 @@ import address.events.*;
 import address.exceptions.DataConversionException;
 import address.model.datatypes.AddressBook;
 import address.model.ModelManager;
-import address.prefs.PrefsManager;
+import address.prefs.UserPrefs;
 import address.storage.StorageManager;
 import address.storage.XmlFileStorage;
+import address.util.TestUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,11 +26,11 @@ import static org.mockito.internal.verification.VerificationModeFactory.times;
 @PrepareForTest(XmlFileStorage.class)
 public class StorageManagerTest {
 
-    private static final File DUMMY_FILE = new File("dummy");
+    private static final File DUMMY_FILE = new File(TestUtil.appendToSandboxPath("dummy.xml"));
     private static final AddressBook EMPTY_ADDRESSBOOK = new AddressBook();
     ModelManager modelManagerMock;
     EventManager eventManagerMock;
-    PrefsManager prefsManagerMock;
+    UserPrefs userPrefsMock;
     StorageManager storageManager;
     StorageManager storageManagerSpy;
 
@@ -42,8 +43,9 @@ public class StorageManagerTest {
         //create mocks for dependencies and inject them into StorageManager object under test
         modelManagerMock = Mockito.mock(ModelManager.class);
         eventManagerMock = Mockito.mock(EventManager.class);
-        prefsManagerMock = Mockito.mock(PrefsManager.class);
-        storageManager = new StorageManager(modelManagerMock, prefsManagerMock);
+        userPrefsMock = Mockito.mock(UserPrefs.class);
+        when(userPrefsMock.getSaveLocation()).thenReturn(DUMMY_FILE);
+        storageManager = new StorageManager(modelManagerMock, userPrefsMock);
         storageManager.setEventManager(eventManagerMock);
 
         // This spy will be used to mock only one method of the object under test

--- a/src/test/java/address/unittests/util/XmlUtilTest.java
+++ b/src/test/java/address/unittests/util/XmlUtilTest.java
@@ -4,6 +4,7 @@ import address.exceptions.DataConversionException;
 import address.model.datatypes.AddressBook;
 import address.util.AddressBookBuilder;
 import address.util.FileUtil;
+import address.util.TestUtil;
 import address.util.XmlUtil;
 import org.junit.Rule;
 import org.junit.Test;
@@ -20,7 +21,7 @@ public class XmlUtilTest {
     private static final File EMPTY_FILE = new File(TEST_DATA_FOLDER + "empty.xml");
     private static final File MISSING_FILE = new File(TEST_DATA_FOLDER + "missing.xml");
     private static final File VALID_FILE = new File(TEST_DATA_FOLDER + "validAddressBook.xml");
-    private static final File TEMP_FILE = new File(TEST_DATA_FOLDER + "tempAddressBook.xml");
+    private static final File TEMP_FILE = new File(TestUtil.appendToSandboxPath("tempAddressBook.xml"));
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();

--- a/src/test/java/address/util/TestUtil.java
+++ b/src/test/java/address/util/TestUtil.java
@@ -1,8 +1,10 @@
 package address.util;
 
+import address.model.datatypes.AddressBook;
 import address.model.datatypes.person.Person;
 import address.model.datatypes.person.ViewablePerson;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -11,6 +13,11 @@ import java.util.stream.Collectors;
  * A utility class for test cases.
  */
 public class TestUtil {
+
+    /**
+     * Folder used for temp files created during testing. Ignored by Git.
+     */
+    public static String SANDBOX_FOLDER = FileUtil.getPath("./src/test/data/sandbox/");
 
     public static List<Person> generateSamplePersonData() {
         final Person[] samplePersonData = {
@@ -25,6 +32,7 @@ public class TestUtil {
                 new Person("Martin", "Mueller")
         };
         return Arrays.asList(samplePersonData);
+        //TODO: can be simplified by AddressBook::generateSampleData util method
     }
 
     public static List<ViewablePerson> generateSampleViewablePersonData() {
@@ -40,5 +48,25 @@ public class TestUtil {
                 new Person("Martin", "Mueller")
         };
         return generateSamplePersonData().stream().map(ViewablePerson::new).collect(Collectors.toList());
+        //TODO: can be simplified by AddressBook::generateSampleData util method
+    }
+
+    /**
+     * Appends the file name to the sandbox folder path
+     * @param fileName
+     * @return
+     */
+    public static String appendToSandboxPath(String fileName) {
+        return SANDBOX_FOLDER + fileName;
+    }
+
+    public static void createDataFileWithSampleData(String filePath) {
+        try {
+            File saveFileForTesting = new File(filePath);
+            FileUtil.createIfMissing(saveFileForTesting);
+            XmlUtil.saveDataToFile(saveFileForTesting, AddressBook.generateSampleData());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
This PR pushes toward making tests (gui tests in particular) more configurable and less coupled from production code/data. e.g. running tests should not mess up the data of the app.
Some things done:
* Cleaned up MainApp code a bit
* Extracted a UserPrefs object
* Removed loading sample data (using menu) from the beginning of GUI tests

Some more work to do though.

