### PR TITLE
Fix bug where nearest hour fails at 11pm

### DIFF
--- a/src/main/java/address/sync/cloud/CloudRateLimitStatus.java
+++ b/src/main/java/address/sync/cloud/CloudRateLimitStatus.java
@@ -48,8 +48,9 @@ public class CloudRateLimitStatus {
 
     private long getNextResetTime() {
         LocalDateTime curTime = LocalDateTime.now();
+        LocalDateTime nextHour = curTime.plusHours(1);
         LocalDateTime nearestHour = LocalDateTime.of(
-                curTime.getYear(), curTime.getMonth(), curTime.getDayOfMonth(), curTime.getHour() + 1,
+                nextHour.getYear(), nextHour.getMonth(), nextHour.getDayOfMonth(), nextHour.getHour(),
                 0, 0, 0);
 
         return nearestHour.toEpochSecond(getSystemTimezone());


### PR DESCRIPTION
The app cannot run because at 11pm the nearest hour creation fails since it will be at hour 24 while the limit is 0 - 23.