### PR TITLE
FxRobot does not recognise META on Mac #337

### DIFF
--- a/src/test/java/address/guitests/GuiTestBase.java
+++ b/src/test/java/address/guitests/GuiTestBase.java
@@ -119,14 +119,29 @@ public class GuiTestBase extends FxRobot {
     }
 
     public FxRobot push(KeyCode... keys) {
-        if (!OsDetector.isOnMac()) return super.push(keys);
+        return super.push(getPlatformSpecificKeyCodes(keys));
+    }
 
+    private KeyCode[] getPlatformSpecificKeyCodes(KeyCode[] keys) {
+        if (!OsDetector.isOnMac()) return keys;
         for (int i = 0; i < keys.length; i++) {
             if (keys[i] == KeyCode.META || keys[i] == KeyCode.SHORTCUT) {
                 keys[i] = KeyCode.COMMAND;
             }
         }
-        return super.push(keys);
+        return keys;
+    }
+
+    public FxRobot press(KeyCode... keys) {
+        return super.press(getPlatformSpecificKeyCodes(keys));
+    }
+
+    public FxRobot release(KeyCode... keys) {
+        return super.release(getPlatformSpecificKeyCodes(keys));
+    }
+
+    public FxRobot type(KeyCode... keys) {
+        return super.type(getPlatformSpecificKeyCodes(keys));
     }
 
     protected void delay(int milliseconds) {

--- a/src/test/java/address/guitests/GuiTestBase.java
+++ b/src/test/java/address/guitests/GuiTestBase.java
@@ -112,14 +112,21 @@ public class GuiTestBase extends FxRobot {
     }
 
     public FxRobot push(KeyCodeCombination keys) {
-        return super.push(getPlatformSpecificKeyCombination(keys));
+        if (!OsDetector.isOnMac()) return super.push(keys);
+        if (keys.getShortcut() != KeyCodeCombination.ModifierValue.DOWN
+                && keys.getMeta() != KeyCodeCombination.ModifierValue.DOWN) return super.push(keys);
+        return push(KeyCode.COMMAND, KeyCode.A);
     }
 
-    private KeyCodeCombination getPlatformSpecificKeyCombination(KeyCodeCombination keys) {
-        if (keys.getShortcut() != KeyCodeCombination.ModifierValue.DOWN) return keys;
-        KeyCodeCombination.Modifier shortcut = OsDetector.isOnMac() ? KeyCodeCombination.META_DOWN
-                                                                    : KeyCodeCombination.CONTROL_DOWN;
-        return new KeyCodeCombination(keys.getCode(), shortcut);
+    public FxRobot push(KeyCode... keys) {
+        if (!OsDetector.isOnMac()) return super.push(keys);
+
+        for (int i = 0; i < keys.length; i++) {
+            if (keys[i] == KeyCode.META || keys[i] == KeyCode.SHORTCUT) {
+                keys[i] = KeyCode.COMMAND;
+            }
+        }
+        return super.push(keys);
     }
 
     protected void delay(int milliseconds) {


### PR DESCRIPTION
Fixes #337 
Will also need to check the `KeyCode`s in `press`, `release` and `type`.