### PR TITLE
Restructured test package structure to match production structure

### DIFF
--- a/src/test/java/address/JsonUtilTest.java
+++ b/src/test/java/address/JsonUtilTest.java
@@ -1,4 +1,4 @@
-package address.unittests;
+package address;
 
 import address.model.datatypes.AddressBook;
 import address.model.datatypes.ReadOnlyAddressBook;

--- a/src/test/java/address/PersonEditDialogModelTest.java
+++ b/src/test/java/address/PersonEditDialogModelTest.java
@@ -1,4 +1,4 @@
-package address.unittests;
+package address;
 
 import address.model.datatypes.tag.Tag;
 import address.model.TagSelectionEditDialogModel;

--- a/src/test/java/address/browser/BrowserManagerTest.java
+++ b/src/test/java/address/browser/BrowserManagerTest.java
@@ -3,11 +3,15 @@ package address.browser;
 import address.util.JavafxRuntimeRule;
 import hubturbo.embeddedbrowser.BrowserType;
 import javafx.collections.FXCollections;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -23,6 +27,19 @@ public class BrowserManagerTest {
      */
     public JavafxRuntimeRule javafxRule = new JavafxRuntimeRule();
 
+    @BeforeClass
+    public void setup(){
+        ExecutorService executor = Executors.newFixedThreadPool(1);
+
+        Runnable task = () -> new BrowserManager(FXCollections.emptyObservableList(),
+                1, BrowserType.FULL_FEATURE_BROWSER).initBrowser();
+        Future<?> future = executor.submit(task);
+        try {
+            future.get();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
 
     @Test
     public void testNecessaryBrowserResources_resourcesNotNull() throws NoSuchMethodException,

--- a/src/test/java/address/browser/BrowserManagerTest.java
+++ b/src/test/java/address/browser/BrowserManagerTest.java
@@ -9,9 +9,6 @@ import org.junit.Test;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -28,17 +25,9 @@ public class BrowserManagerTest {
     public JavafxRuntimeRule javafxRule = new JavafxRuntimeRule();
 
     @BeforeClass
-    public void setup(){
-        ExecutorService executor = Executors.newFixedThreadPool(1);
-
-        Runnable task = () -> new BrowserManager(FXCollections.emptyObservableList(),
+    public static void setup(){
+        new BrowserManager(FXCollections.emptyObservableList(),
                 1, BrowserType.FULL_FEATURE_BROWSER).initBrowser();
-        Future<?> future = executor.submit(task);
-        try {
-            future.get();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
     }
 
     @Test

--- a/src/test/java/address/browser/BrowserManagerTest.java
+++ b/src/test/java/address/browser/BrowserManagerTest.java
@@ -1,6 +1,6 @@
 package address.browser;
 
-import address.util.JavafxThreadingRule;
+import address.util.JavafxRuntimeRule;
 import hubturbo.embeddedbrowser.BrowserType;
 import javafx.collections.FXCollections;
 import org.junit.Rule;
@@ -21,7 +21,7 @@ public class BrowserManagerTest {
     /**
      * To run test cases on JavaFX thread.
      */
-    public JavafxThreadingRule javafxRule = new JavafxThreadingRule();
+    public JavafxRuntimeRule javafxRule = new JavafxRuntimeRule();
 
 
     @Test

--- a/src/test/java/address/browser/BrowserManagerTest.java
+++ b/src/test/java/address/browser/BrowserManagerTest.java
@@ -1,6 +1,5 @@
-package address.unittests.browser;
+package address.browser;
 
-import address.browser.BrowserManager;
 import address.util.JavafxThreadingRule;
 import hubturbo.embeddedbrowser.BrowserType;
 import javafx.collections.FXCollections;
@@ -10,10 +9,8 @@ import org.junit.Test;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import static junit.framework.TestCase.assertFalse;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+
 
 /**
  * Tests the BrowserManager behaviours and functionality.

--- a/src/test/java/address/browser/EmbeddedBrowserObjectMapperTest.java
+++ b/src/test/java/address/browser/EmbeddedBrowserObjectMapperTest.java
@@ -1,4 +1,4 @@
-package address.unittests.browser;
+package address.browser;
 
 import hubturbo.embeddedbrowser.EbEditorCommand;
 import hubturbo.embeddedbrowser.jxbrowser.EmbeddedBrowserObjectMapper;

--- a/src/test/java/address/browser/HyperBrowserTest.java
+++ b/src/test/java/address/browser/HyperBrowserTest.java
@@ -44,7 +44,7 @@ public class HyperBrowserTest {
     }
 
     @BeforeClass
-    public void setup(){
+    public static void setup(){
         new BrowserManager(FXCollections.emptyObservableList(),
                 1, BrowserType.FULL_FEATURE_BROWSER).initBrowser();
     }

--- a/src/test/java/address/browser/HyperBrowserTest.java
+++ b/src/test/java/address/browser/HyperBrowserTest.java
@@ -5,6 +5,8 @@ import hubturbo.embeddedbrowser.BrowserType;
 import hubturbo.embeddedbrowser.HyperBrowser;
 import hubturbo.embeddedbrowser.page.Page;
 import address.util.UrlUtil;
+import javafx.collections.FXCollections;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.Rule;
 
@@ -39,6 +41,12 @@ public class HyperBrowserTest {
             new URL("https://bitbucket.org"));
 
     public HyperBrowserTest() throws MalformedURLException {
+    }
+
+    @BeforeClass
+    public void setup(){
+        new BrowserManager(FXCollections.emptyObservableList(),
+                1, BrowserType.FULL_FEATURE_BROWSER).initBrowser();
     }
 
     @Test

--- a/src/test/java/address/browser/HyperBrowserTest.java
+++ b/src/test/java/address/browser/HyperBrowserTest.java
@@ -1,9 +1,9 @@
 package address.browser;
 
+import address.util.JavafxRuntimeRule;
 import hubturbo.embeddedbrowser.BrowserType;
 import hubturbo.embeddedbrowser.HyperBrowser;
 import hubturbo.embeddedbrowser.page.Page;
-import address.util.JavafxThreadingRule;
 import address.util.UrlUtil;
 import org.junit.Test;
 import org.junit.Rule;
@@ -29,7 +29,7 @@ public class HyperBrowserTest {
     /**
      * To run test cases on JavaFX thread.
      */
-    public JavafxThreadingRule javafxRule = new JavafxThreadingRule();
+    public JavafxRuntimeRule javafxRule = new JavafxRuntimeRule();
 
     List<URL> listOfUrl = Arrays.asList(new URL("https://github.com"),
             new URL("https://google.com.sg"),

--- a/src/test/java/address/browser/HyperBrowserTest.java
+++ b/src/test/java/address/browser/HyperBrowserTest.java
@@ -1,4 +1,4 @@
-package address.unittests.browser;
+package address.browser;
 
 import hubturbo.embeddedbrowser.BrowserType;
 import hubturbo.embeddedbrowser.HyperBrowser;

--- a/src/test/java/address/guitests/FullSystemTest.java
+++ b/src/test/java/address/guitests/FullSystemTest.java
@@ -1,5 +1,6 @@
 package address.guitests;
 
+import guitests.GuiTestBase;
 import javafx.scene.input.KeyCode;
 import org.junit.Test;
 

--- a/src/test/java/address/guitests/PersonOverviewTest.java
+++ b/src/test/java/address/guitests/PersonOverviewTest.java
@@ -1,5 +1,6 @@
 package address.guitests;
 
+import guitests.GuiTestBase;
 import javafx.scene.control.Label;
 import org.junit.Test;
 

--- a/src/test/java/address/keybindings/KeyBindingsManagerApiTest.java
+++ b/src/test/java/address/keybindings/KeyBindingsManagerApiTest.java
@@ -1,11 +1,8 @@
-package address.unittests.keybindings;
+package address.keybindings;
 
 
 import address.events.*;
-import address.keybindings.Accelerator;
-import address.keybindings.Bindings;
-import address.keybindings.KeyBinding;
-import address.keybindings.KeySequence;
+
 import address.util.TestUtil;
 import javafx.scene.input.KeyCombination;
 import org.junit.Assert;

--- a/src/test/java/address/keybindings/KeyBindingsManagerEx.java
+++ b/src/test/java/address/keybindings/KeyBindingsManagerEx.java
@@ -1,8 +1,6 @@
-package address.unittests.keybindings;
+package address.keybindings;
 
 import address.events.KeyBindingEvent;
-import address.keybindings.KeyBinding;
-import address.keybindings.KeyBindingsManager;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/test/java/address/model/AddPersonCommandTest.java
+++ b/src/test/java/address/model/AddPersonCommandTest.java
@@ -5,7 +5,7 @@ import address.model.ChangeObjectInModelCommand.State;
 import address.model.datatypes.person.Person;
 import address.model.datatypes.person.ReadOnlyPerson;
 import address.model.datatypes.person.ViewablePerson;
-import address.util.JavafxThreadingRule;
+import address.util.JavafxRuntimeRule;
 import address.util.TestUtil;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
@@ -31,7 +31,7 @@ public class AddPersonCommandTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
     @Rule
-    public JavafxThreadingRule javafxRule = new JavafxThreadingRule();
+    public JavafxRuntimeRule javafxRule = new JavafxRuntimeRule();
 
     @Mock
     ModelManager modelManagerMock;

--- a/src/test/java/address/model/DeletePersonCommandTest.java
+++ b/src/test/java/address/model/DeletePersonCommandTest.java
@@ -2,10 +2,9 @@ package address.model;
 
 import address.events.DeletePersonOnRemoteRequestEvent;
 import address.model.ChangeObjectInModelCommand.State;
-import address.model.datatypes.person.Person;
 import address.model.datatypes.person.ReadOnlyPerson;
 import address.model.datatypes.person.ViewablePerson;
-import address.util.JavafxThreadingRule;
+import address.util.JavafxRuntimeRule;
 import address.util.TestUtil;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
@@ -31,7 +30,7 @@ public class DeletePersonCommandTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
     @Rule
-    public JavafxThreadingRule javafxRule = new JavafxThreadingRule();
+    public JavafxRuntimeRule javafxRule = new JavafxRuntimeRule();
 
     @Mock
     ModelManager modelManagerMock;

--- a/src/test/java/address/model/EditPersonCommandTest.java
+++ b/src/test/java/address/model/EditPersonCommandTest.java
@@ -5,7 +5,7 @@ import address.model.ChangeObjectInModelCommand.State;
 import address.model.datatypes.person.Person;
 import address.model.datatypes.person.ReadOnlyPerson;
 import address.model.datatypes.person.ViewablePerson;
-import address.util.JavafxThreadingRule;
+import address.util.JavafxRuntimeRule;
 import address.util.TestUtil;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
@@ -31,7 +31,7 @@ public class EditPersonCommandTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
     @Rule
-    public JavafxThreadingRule javafxRule = new JavafxThreadingRule();
+    public JavafxRuntimeRule javafxRule = new JavafxRuntimeRule();
 
     @Mock
     ModelManager modelManagerMock;

--- a/src/test/java/address/storage/StorageManagerTest.java
+++ b/src/test/java/address/storage/StorageManagerTest.java
@@ -1,14 +1,10 @@
-package address.unittests.storage;
+package address.storage;
 
 import address.events.*;
 import address.exceptions.DataConversionException;
 import address.model.ModelManager;
 import address.model.UserPrefs;
 import address.model.datatypes.AddressBook;
-import address.model.datatypes.ReadOnlyAddressBook;
-import address.storage.StorageAddressBook;
-import address.storage.StorageManager;
-import address.storage.XmlFileStorage;
 import address.util.Config;
 import address.util.FileUtil;
 import address.util.SerializableTestClass;

--- a/src/test/java/address/storage/XmlFileStorageTest.java
+++ b/src/test/java/address/storage/XmlFileStorageTest.java
@@ -1,8 +1,6 @@
-package address.unittests.storage;
+package address.storage;
 
 import address.model.datatypes.AddressBook;
-import address.storage.StorageAddressBook;
-import address.storage.XmlFileStorage;
 import address.util.XmlUtil;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/address/sync/RemoteManagerTest.java
+++ b/src/test/java/address/sync/RemoteManagerTest.java
@@ -1,10 +1,7 @@
-package address.unittests.sync;
+package address.sync;
 
 import address.model.datatypes.person.Person;
 import address.model.datatypes.tag.Tag;
-import address.sync.ExtractedRemoteResponse;
-import address.sync.RemoteManager;
-import address.sync.RemoteService;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/address/sync/RemoteServiceTest.java
+++ b/src/test/java/address/sync/RemoteServiceTest.java
@@ -1,12 +1,10 @@
-package address.unittests.sync;
+package address.sync;
 
 import address.model.datatypes.person.Person;
 import address.model.datatypes.tag.Tag;
 import address.sync.cloud.CloudRateLimitStatus;
 import address.sync.cloud.RemoteResponse;
-import address.sync.RemoteService;
 import address.sync.cloud.CloudSimulator;
-import address.sync.ExtractedRemoteResponse;
 import address.sync.cloud.model.CloudPerson;
 import address.sync.cloud.model.CloudTag;
 import org.junit.Before;

--- a/src/test/java/address/sync/SyncManagerTest.java
+++ b/src/test/java/address/sync/SyncManagerTest.java
@@ -1,12 +1,10 @@
-package address.unittests.sync;
+package address.sync;
 
 import address.events.CreatePersonOnRemoteRequestEvent;
 import address.events.EventManager;
 import address.events.SyncFailedEvent;
 import address.model.datatypes.person.Person;
 import address.model.datatypes.person.ReadOnlyPerson;
-import address.sync.RemoteManager;
-import address.sync.SyncManager;
 import address.sync.task.CreatePersonOnRemoteTask;
 import address.util.Config;
 import com.google.common.eventbus.Subscribe;

--- a/src/test/java/address/sync/cloud/CloudSimulatorTest.java
+++ b/src/test/java/address/sync/cloud/CloudSimulatorTest.java
@@ -1,10 +1,6 @@
-package address.unittests.sync.cloud;
+package address.sync.cloud;
 
 import address.exceptions.DataConversionException;
-import address.sync.cloud.RemoteResponse;
-import address.sync.cloud.CloudFileHandler;
-import address.sync.cloud.CloudRateLimitStatus;
-import address.sync.cloud.CloudSimulator;
 import address.sync.cloud.model.CloudAddressBook;
 import address.sync.cloud.model.CloudPerson;
 import address.sync.cloud.model.CloudTag;

--- a/src/test/java/address/util/FileUtilTest.java
+++ b/src/test/java/address/util/FileUtilTest.java
@@ -1,7 +1,6 @@
-package address.unittests.util;
+package address.util;
 
 
-import address.util.FileUtil;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/src/test/java/address/util/JavaVersionTest.java
+++ b/src/test/java/address/util/JavaVersionTest.java
@@ -1,7 +1,6 @@
-package address.unittests.util;
+package address.util;
 
 import address.MainApp;
-import address.util.JavaVersion;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/address/util/JavafxRuntimeRule.java
+++ b/src/test/java/address/util/JavafxRuntimeRule.java
@@ -1,13 +1,5 @@
 package address.util;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-
-import address.browser.BrowserManager;
-import hubturbo.embeddedbrowser.BrowserType;
-import javafx.collections.FXCollections;
-
 import org.junit.*;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -22,16 +14,7 @@ import org.testfx.api.FxToolkit;
 public class JavafxRuntimeRule implements TestRule {
 
     public JavafxRuntimeRule() {
-        ExecutorService executor = Executors.newFixedThreadPool(1);
 
-        Runnable task = () -> new BrowserManager(FXCollections.emptyObservableList(),
-                                                 1, BrowserType.FULL_FEATURE_BROWSER).initBrowser();
-        Future<?> future = executor.submit(task);
-        try {
-            future.get();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
     }
 
     @BeforeClass

--- a/src/test/java/address/util/JavafxRuntimeRule.java
+++ b/src/test/java/address/util/JavafxRuntimeRule.java
@@ -15,26 +15,13 @@ import org.junit.runners.model.Statement;
 import org.testfx.api.FxToolkit;
 
 /**
- * A JUnit {@link Rule} for running tests on the JavaFX thread and performing
+ * A JUnit {@link Rule} for running tests that requires
  * JavaFX initialisation.  To include in your test case, add the following code:
- *
- * <pre>
- * {@literal @}Rule
- * public JavafxThreadingRule jfxRule = new JavafxThreadingRule();
- * </pre>
- *
- * @author Andy Till
- *
+ * public JavafxRuntimeRule jfxRule = new JavafxRuntimeRule();
  */
-public class JavafxThreadingRule implements TestRule {
-    private static final AppLogger logger = LoggerManager.getLogger(JavafxThreadingRule.class);
+public class JavafxRuntimeRule implements TestRule {
 
-    /**
-     * Flag for setting up the JavaFX, we only need to do this once for all tests.
-     */
-    private static boolean jfxIsSetup;
-
-    public JavafxThreadingRule() {
+    public JavafxRuntimeRule() {
         ExecutorService executor = Executors.newFixedThreadPool(1);
 
         Runnable task = () -> new BrowserManager(FXCollections.emptyObservableList(),
@@ -61,22 +48,13 @@ public class JavafxThreadingRule implements TestRule {
     @Override
     public Statement apply(Statement statement, Description description) {
 
-        return new OnJFXThreadStatement(statement);
+        return new OnJFXThreadStatement();
     }
 
     private static class OnJFXThreadStatement extends Statement {
-
-        private final Statement statement;
-
-        public OnJFXThreadStatement(Statement aStatement) {
-            statement = aStatement;
-        }
-
-
         @Override
         public void evaluate() throws Throwable {
 
         }
-
     }
 }

--- a/src/test/java/address/util/UrlUtilTest.java
+++ b/src/test/java/address/util/UrlUtilTest.java
@@ -1,7 +1,7 @@
-package address.unittests.util;
+package address.util;
 
-import address.util.UrlUtil;
 import junit.framework.TestCase;
+
 import org.junit.Test;
 
 import java.net.MalformedURLException;

--- a/src/test/java/address/util/XmlUtilTest.java
+++ b/src/test/java/address/util/XmlUtilTest.java
@@ -1,12 +1,8 @@
-package address.unittests.util;
+package address.util;
 
 import address.exceptions.DataConversionException;
 import address.model.datatypes.AddressBook;
 import address.storage.StorageAddressBook;
-import address.util.AddressBookBuilder;
-import address.util.FileUtil;
-import address.util.TestUtil;
-import address.util.XmlUtil;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/src/test/java/guitests/GuiTestBase.java
+++ b/src/test/java/guitests/GuiTestBase.java
@@ -1,4 +1,4 @@
-package address.guitests;
+package guitests;
 
 import address.TestApp;
 import address.events.EventManager;

--- a/src/test/java/guitests/KeyBindingsGuiTest.java
+++ b/src/test/java/guitests/KeyBindingsGuiTest.java
@@ -1,4 +1,4 @@
-package address.guitests;
+package guitests;
 
 import address.keybindings.Bindings;
 import address.model.datatypes.AddressBook;

--- a/src/test/java/guitests/PersonEditDialogTest.java
+++ b/src/test/java/guitests/PersonEditDialogTest.java
@@ -1,4 +1,4 @@
-package address.guitests;
+package guitests;
 
 import javafx.scene.input.KeyCode;
 import org.junit.Test;

--- a/src/test/java/guitests/TagEditDialogTest.java
+++ b/src/test/java/guitests/TagEditDialogTest.java
@@ -1,6 +1,7 @@
-package address.guitests;
+package guitests;
 
 import javafx.scene.input.KeyCode;
+
 import org.junit.Test;
 
 import static org.testfx.api.FxAssert.verifyThat;

--- a/src/test/java/guitests/TagListTest.java
+++ b/src/test/java/guitests/TagListTest.java
@@ -1,4 +1,4 @@
-package address.guitests;
+package guitests;
 
 import org.junit.Test;
 

--- a/src/test/java/guiunittests/TagSelectionEditDialogUnitTest.java
+++ b/src/test/java/guiunittests/TagSelectionEditDialogUnitTest.java
@@ -1,4 +1,4 @@
-package address.guiunittests;
+package guiunittests;
 
 import address.TestApp;
 import address.controller.TagSelectionEditDialogController;


### PR DESCRIPTION
GUI tests remain in their own packages.

Unit tests go from `address.unittests.*` to `address.*`. This allows easier testing and mocking of dependent classes in the same package.