### PR TITLE
Model maintains command history #412

### DIFF
--- a/src/main/java/address/model/AddPersonCommand.java
+++ b/src/main/java/address/model/AddPersonCommand.java
@@ -144,7 +144,7 @@ public class AddPersonCommand extends ChangePersonInModelCommand {
             logger.debug("requestChangeToRemote -> id of viewable person updated to " + viewableToAdd.getId());
             return SUCCESSFUL;
         } catch (ExecutionException | InterruptedException e) {
-            return CANCELLED; // figure out a policy for syncup fail
+            return FAILED;
         }
     }
 
@@ -162,7 +162,7 @@ public class AddPersonCommand extends ChangePersonInModelCommand {
 
     @Override
     protected void finishWithFailure() {
-        // no way to fail for now
+        finishWithCancel(); // TODO figure out failure handling
     }
 
 }

--- a/src/main/java/address/model/AddPersonCommand.java
+++ b/src/main/java/address/model/AddPersonCommand.java
@@ -34,11 +34,11 @@ public class AddPersonCommand extends ChangePersonInModelCommand {
      * @param inputRetriever Will run on execution {@link #run()} thread. This should handle thread concurrency
      *                       logic (eg. {@link PlatformExecUtil#call(Callable)} within itself.
      *                       If the returned Optional is empty, the command will be cancelled.
-     * @see super#ChangePersonInModelCommand(Supplier, int)
+     * @see super#ChangePersonInModelCommand(int, Supplier, int)
      */
-    public AddPersonCommand(Supplier<Optional<ReadOnlyPerson>> inputRetriever, int gracePeriodDurationInSeconds,
+    public AddPersonCommand(int commandId, Supplier<Optional<ReadOnlyPerson>> inputRetriever, int gracePeriodDurationInSeconds,
                                Consumer<BaseEvent> eventRaiser, ModelManager model) {
-        super(inputRetriever, gracePeriodDurationInSeconds);
+        super(commandId, inputRetriever, gracePeriodDurationInSeconds);
         this.model = model;
         this.eventRaiser = eventRaiser;
         this.addressbookName = model.getPrefs().getSaveFileName();

--- a/src/main/java/address/model/AddPersonCommand.java
+++ b/src/main/java/address/model/AddPersonCommand.java
@@ -50,7 +50,7 @@ public class AddPersonCommand extends ChangePersonInModelCommand {
 
     @Override
     public String getName() {
-        return "Add Person";
+        return "Add Person " + (viewableToAdd == null ? "" : viewableToAdd.idString());
     }
 
     @Override
@@ -71,6 +71,7 @@ public class AddPersonCommand extends ChangePersonInModelCommand {
         if (viewableToAdd != null) {
             model.unassignOngoingChangeForPerson(viewableToAdd.getId());
         }
+        model.trackFinishedCommand(this);
     }
 
     /**

--- a/src/main/java/address/model/AddPersonCommand.java
+++ b/src/main/java/address/model/AddPersonCommand.java
@@ -49,6 +49,11 @@ public class AddPersonCommand extends ChangePersonInModelCommand {
     }
 
     @Override
+    public String getName() {
+        return "Add Person";
+    }
+
+    @Override
     public int getTargetPersonId() {
         if (viewableToAdd == null) {
             throw new IllegalStateException("Add person command has not created the proposed ViewablePerson yet.");

--- a/src/main/java/address/model/ChangeObjectInModelCommand.java
+++ b/src/main/java/address/model/ChangeObjectInModelCommand.java
@@ -19,21 +19,34 @@ import static address.model.ChangeObjectInModelCommand.State.*;
  *
  * Should be run OUTSIDE THE FX THREAD because the {@link #run()} method involves blocking calls.
  */
-public abstract class ChangeObjectInModelCommand implements Runnable {
+public abstract class ChangeObjectInModelCommand implements Runnable, CommandInfo {
 
     public enum State {
         // Initial state
-        NEWLY_CREATED,
+        NEWLY_CREATED ("Newly Created"),
 
         // Intermediate states
-        RETRIEVING_INPUT,
-        SIMULATING_RESULT,
-        GRACE_PERIOD,
-        CHECKING_AND_RESOLVING_REMOTE_CONFLICT,
-        REQUESTING_REMOTE_CHANGE,
+        RETRIEVING_INPUT ("Retrieving Input"),
+        SIMULATING_RESULT ("Optimistically Simulating Result"),
+        GRACE_PERIOD ("Pending / Grace Period"),
+        CHECKING_AND_RESOLVING_REMOTE_CONFLICT ("Handling any Remote Conflicts"),
+        REQUESTING_REMOTE_CHANGE ("Request to Remote"),
 
         // Terminal states
-        CANCELLED, SUCCESSFUL, FAILED,
+        CANCELLED ("Cancelled"),
+        SUCCESSFUL ("Successful"),
+        FAILED ("Failed");
+
+        private final String msg;
+
+        State(String msg) {
+            this.msg = msg;
+        }
+
+        @Override
+        public String toString() {
+            return msg;
+        }
     }
 
     private static final AppLogger logger = LoggerManager.getLogger(ChangeObjectInModelCommand.class);
@@ -61,6 +74,11 @@ public abstract class ChangeObjectInModelCommand implements Runnable {
 
     public State getState() {
         return state.getValue();
+    }
+
+    @Override
+    public String statusString() {
+        return getState().toString();
     }
 
     void setState(State newState) {

--- a/src/main/java/address/model/ChangeObjectInModelCommand.java
+++ b/src/main/java/address/model/ChangeObjectInModelCommand.java
@@ -51,6 +51,8 @@ public abstract class ChangeObjectInModelCommand implements Runnable, CommandInf
 
     private static final AppLogger logger = LoggerManager.getLogger(ChangeObjectInModelCommand.class);
 
+    private final int commandId;
+
     private final CountDownLatch completionLatch;
     protected final int gracePeriodDurationInSeconds;
     protected final ObjectProperty<State> state; // current state
@@ -64,8 +66,14 @@ public abstract class ChangeObjectInModelCommand implements Runnable, CommandInf
         clearGracePeriodOverride();
     }
 
-    protected ChangeObjectInModelCommand(int gracePeriodDurationInSeconds) {
+    protected ChangeObjectInModelCommand(int commandId, int gracePeriodDurationInSeconds) {
+        this.commandId = commandId;
         this.gracePeriodDurationInSeconds = gracePeriodDurationInSeconds;
+    }
+
+    @Override
+    public int getCommandId() {
+        return commandId;
     }
 
     public void waitForCompletion() throws InterruptedException {

--- a/src/main/java/address/model/ChangePersonInModelCommand.java
+++ b/src/main/java/address/model/ChangePersonInModelCommand.java
@@ -29,9 +29,9 @@ public abstract class ChangePersonInModelCommand extends ChangeObjectInModelComm
      *                       logic (eg. {@link PlatformExecUtil#call(Callable)} within itself.
      *                       If the returned Optional is empty, the command will be cancelled.
      */
-    protected ChangePersonInModelCommand(Supplier<Optional<ReadOnlyPerson>> inputRetriever,
+    protected ChangePersonInModelCommand(int commandId, Supplier<Optional<ReadOnlyPerson>> inputRetriever,
                                          int gracePeriodDurationInSeconds) {
-        super(gracePeriodDurationInSeconds);
+        super(commandId, gracePeriodDurationInSeconds);
         this.inputRetriever = inputRetriever;
     }
 

--- a/src/main/java/address/model/CommandInfo.java
+++ b/src/main/java/address/model/CommandInfo.java
@@ -1,0 +1,6 @@
+package address.model;
+
+public interface CommandInfo {
+    String getName();
+    String statusString();
+}

--- a/src/main/java/address/model/CommandInfo.java
+++ b/src/main/java/address/model/CommandInfo.java
@@ -1,6 +1,7 @@
 package address.model;
 
 public interface CommandInfo {
+    int getCommandId(); // id == command counter (starting from 1)
     String getName();
     String statusString();
 }

--- a/src/main/java/address/model/DeletePersonCommand.java
+++ b/src/main/java/address/model/DeletePersonCommand.java
@@ -120,7 +120,7 @@ public class DeletePersonCommand extends ChangePersonInModelCommand {
             PlatformExecUtil.runAndWait(() -> model.backingModel().removePerson(target));
             return SUCCESSFUL;
         } catch (ExecutionException | InterruptedException e) {
-            return CANCELLED; // figure out a policy for syncup fail
+            return FAILED;
         }
     }
 
@@ -136,6 +136,6 @@ public class DeletePersonCommand extends ChangePersonInModelCommand {
 
     @Override
     protected void finishWithFailure() {
-        // Impossible for now
+        finishWithCancel(); // TODO figure out failure handling
     }
 }

--- a/src/main/java/address/model/DeletePersonCommand.java
+++ b/src/main/java/address/model/DeletePersonCommand.java
@@ -73,6 +73,7 @@ public class DeletePersonCommand extends ChangePersonInModelCommand {
             target.setIsDeleted(false);
         });
         model.unassignOngoingChangeForPerson(target.getId());
+        model.trackFinishedCommand(this);
     }
 
     @Override

--- a/src/main/java/address/model/DeletePersonCommand.java
+++ b/src/main/java/address/model/DeletePersonCommand.java
@@ -26,12 +26,12 @@ public class DeletePersonCommand extends ChangePersonInModelCommand {
     private final String addressbookName;
 
     /**
-     * @see super#ChangePersonInModelCommand(Supplier, int)
+     * @see super#ChangePersonInModelCommand(int, Supplier, int)
      */
-    public DeletePersonCommand(ViewablePerson target, int gracePeriodDurationInSeconds,
+    public DeletePersonCommand(int commandId, ViewablePerson target, int gracePeriodDurationInSeconds,
                                   Consumer<BaseEvent> eventRaiser, ModelManager model) {
         // no input needed for delete commands
-        super(() -> Optional.of(target), gracePeriodDurationInSeconds);
+        super(commandId, () -> Optional.of(target), gracePeriodDurationInSeconds);
         this.target = target;
         this.model = model;
         this.eventRaiser = eventRaiser;

--- a/src/main/java/address/model/DeletePersonCommand.java
+++ b/src/main/java/address/model/DeletePersonCommand.java
@@ -48,6 +48,11 @@ public class DeletePersonCommand extends ChangePersonInModelCommand {
     }
 
     @Override
+    public String getName() {
+        return "Delete Person " + target.idString();
+    }
+
+    @Override
     protected void before() {
         if (model.personHasOngoingChange(target)) {
             try {

--- a/src/main/java/address/model/EditPersonCommand.java
+++ b/src/main/java/address/model/EditPersonCommand.java
@@ -135,7 +135,7 @@ public class EditPersonCommand extends ChangePersonInModelCommand {
             PlatformExecUtil.runAndWait(() -> target.getBacking().update(input));
             return SUCCESSFUL;
         } catch (ExecutionException | InterruptedException e) {
-            return CANCELLED; // figure out a policy for syncup fail
+            return FAILED;
         }
     }
 
@@ -151,6 +151,6 @@ public class EditPersonCommand extends ChangePersonInModelCommand {
 
     @Override
     protected void finishWithFailure() {
-        // can't happen yet
+        finishWithCancel(); // TODO figure out failure handling
     }
 }

--- a/src/main/java/address/model/EditPersonCommand.java
+++ b/src/main/java/address/model/EditPersonCommand.java
@@ -30,12 +30,12 @@ public class EditPersonCommand extends ChangePersonInModelCommand {
      * @param inputRetriever Will run on execution {@link #run()} thread. This should handle thread concurrency
      *                       logic (eg. {@link PlatformExecUtil#call(Callable)} within itself.
      *                       If the returned Optional is empty, the command will be cancelled.
-     * @see super#ChangePersonInModelCommand(Supplier, int)
+     * @see super#ChangePersonInModelCommand(int, Supplier, int)
      */
-    public EditPersonCommand(ViewablePerson target, Supplier<Optional<ReadOnlyPerson>> inputRetriever,
+    public EditPersonCommand(int commandId, ViewablePerson target, Supplier<Optional<ReadOnlyPerson>> inputRetriever,
                                 int gracePeriodDurationInSeconds, Consumer<BaseEvent> eventRaiser,
                                 ModelManager model) {
-        super(inputRetriever, gracePeriodDurationInSeconds);
+        super(commandId, inputRetriever, gracePeriodDurationInSeconds);
         assert target != null;
         this.target = target;
         this.model = model;

--- a/src/main/java/address/model/EditPersonCommand.java
+++ b/src/main/java/address/model/EditPersonCommand.java
@@ -53,6 +53,11 @@ public class EditPersonCommand extends ChangePersonInModelCommand {
     }
 
     @Override
+    public String getName() {
+        return "Edit Person " + target.idString();
+    }
+
+    @Override
     protected void before() {
         if (model.personHasOngoingChange(target)) {
             try {

--- a/src/main/java/address/model/EditPersonCommand.java
+++ b/src/main/java/address/model/EditPersonCommand.java
@@ -27,9 +27,9 @@ public class EditPersonCommand extends ChangePersonInModelCommand {
     private final String addressbookName;
 
     /**
-     * @param inputRetriever               Will run on execution {@link #run()} thread. This should handle thread concurrency
-     *                                     logic (eg. {@link PlatformExecUtil#call(Callable)} within itself.
-     *                                     If the returned Optional is empty, the command will be cancelled.
+     * @param inputRetriever Will run on execution {@link #run()} thread. This should handle thread concurrency
+     *                       logic (eg. {@link PlatformExecUtil#call(Callable)} within itself.
+     *                       If the returned Optional is empty, the command will be cancelled.
      * @see super#ChangePersonInModelCommand(Supplier, int)
      */
     public EditPersonCommand(ViewablePerson target, Supplier<Optional<ReadOnlyPerson>> inputRetriever,
@@ -78,6 +78,7 @@ public class EditPersonCommand extends ChangePersonInModelCommand {
             target.setIsEdited(false);
         });
         model.unassignOngoingChangeForPerson(target.getId());
+        model.trackFinishedCommand(this);
     }
 
     @Override

--- a/src/main/java/address/model/ModelManager.java
+++ b/src/main/java/address/model/ModelManager.java
@@ -15,6 +15,7 @@ import address.util.PlatformExecUtil;
 import address.util.collections.UnmodifiableObservableList;
 import com.google.common.eventbus.Subscribe;
 
+import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 
@@ -35,13 +36,15 @@ public class ModelManager extends ComponentManager implements ReadOnlyAddressBoo
     private final AddressBook backingModel;
     private final ViewableAddressBook visibleModel;
     private final Map<Integer, ChangePersonInModelCommand> personChangesInProgress;
+    private final ObservableList<ChangeObjectInModelCommand> finishedCommands;
 
-    final Executor commandExecutor;
+    private final Executor commandExecutor;
     private UserPrefs prefs;
 
     {
         personChangesInProgress = new HashMap<>();
         commandExecutor = Executors.newCachedThreadPool();
+        finishedCommands = FXCollections.observableArrayList();
     }
 
     /**
@@ -94,6 +97,10 @@ public class ModelManager extends ComponentManager implements ReadOnlyAddressBoo
     }
 
 //// EXPOSING MODEL
+
+    public UnmodifiableObservableList<CommandInfo> getFinishedCommands() {
+        return new UnmodifiableObservableList<>(finishedCommands);
+    }
 
     /**
      * @return all persons in visible model IN AN UNMODIFIABLE VIEW
@@ -308,6 +315,10 @@ public class ModelManager extends ComponentManager implements ReadOnlyAddressBoo
 
     void raiseLocalModelChangedEvent() {
         raise(new LocalModelChangedEvent(this));
+    }
+
+    void trackFinishedCommand(ChangeObjectInModelCommand finished) {
+        finishedCommands.add(finished);
     }
 
 //// CREATE

--- a/src/test/java/address/model/AddPersonCommandTest.java
+++ b/src/test/java/address/model/AddPersonCommandTest.java
@@ -71,7 +71,7 @@ public class AddPersonCommandTest {
 
     @Test
     public void getTargetPersonId_throws_whenViewableNotCreatedYet() {
-        final AddPersonCommand apc = new AddPersonCommand(null, 0, null, modelManagerMock);
+        final AddPersonCommand apc = new AddPersonCommand(0, null, 0, null, modelManagerMock);
         thrown.expect(IllegalStateException.class);
         apc.getTargetPersonId();
     }
@@ -80,7 +80,7 @@ public class AddPersonCommandTest {
     public void getTargetPersonId_returnsTempId_afterResultSimulatedAndBeforeRemoteChange() {
         final ViewablePerson createdViewable = ViewablePerson.withoutBacking(Person.createPersonDataContainer());
         final int CORRECT_ID = createdViewable.getId();
-        final AddPersonCommand apc = spy(new AddPersonCommand(returnValidEmptyInput, 0, null, modelManagerMock));
+        final AddPersonCommand apc = spy(new AddPersonCommand(0, returnValidEmptyInput, 0, null, modelManagerMock));
 
         when(modelManagerMock.addViewablePersonWithoutBacking(notNull(ReadOnlyPerson.class))).thenReturn(createdViewable);
 
@@ -103,7 +103,7 @@ public class AddPersonCommandTest {
                         new Person(CORRECT_ID).update(e.getCreatedPerson()));
             }
         });
-        final AddPersonCommand apc = new AddPersonCommand(returnValidEmptyInput, 0, events::post, modelManagerSpy);
+        final AddPersonCommand apc = new AddPersonCommand(0, returnValidEmptyInput, 0, events::post, modelManagerSpy);
 
         apc.run();
         assertEquals(apc.getTargetPersonId(), CORRECT_ID);
@@ -111,7 +111,7 @@ public class AddPersonCommandTest {
 
     @Test
     public void retrievingInput_cancelsCommand_whenEmptyInputOptionalRetrieved() {
-        final AddPersonCommand apc = new AddPersonCommand(Optional::empty, 0, null, modelManagerMock);
+        final AddPersonCommand apc = new AddPersonCommand(0, Optional::empty, 0, null, modelManagerMock);
         apc.run();
         assertEquals(apc.getState(), State.CANCELLED);
     }
@@ -119,7 +119,7 @@ public class AddPersonCommandTest {
     @Test
     public void optimisticUiUpdate_simulatesCorrectData() {
         final ReadOnlyPerson inputData = TestUtil.generateSamplePersonWithAllData(0);
-        final AddPersonCommand apc = spy(new AddPersonCommand(inputRetrieverWrapper(inputData), 0, null, modelManagerSpy));
+        final AddPersonCommand apc = spy(new AddPersonCommand(0, inputRetrieverWrapper(inputData), 0, null, modelManagerSpy));
 
         // to stop the run at start of grace period (right after simulated change)
         doThrow(new InterruptAndTerminateException()).when(apc).beforeGracePeriod();
@@ -136,7 +136,7 @@ public class AddPersonCommandTest {
     @Test
     public void successfulAdd_updatesBackingModelCorrectly() {
         final ReadOnlyPerson inputData = TestUtil.generateSamplePersonWithAllData(0);
-        final AddPersonCommand apc = new AddPersonCommand(inputRetrieverWrapper(inputData), 0, events::post, modelManagerSpy);
+        final AddPersonCommand apc = new AddPersonCommand(0, inputRetrieverWrapper(inputData), 0, events::post, modelManagerSpy);
 
         apc.run();
         assertFalse(modelManagerSpy.personHasOngoingChange(apc.getViewableToAdd()));
@@ -147,7 +147,7 @@ public class AddPersonCommandTest {
     @Test
     public void interruptGracePeriod_withEditRequest_changesAddedPersonData() {
         // grace period duration must be non zero, will be interrupted immediately anyway
-        final AddPersonCommand apc = spy(new AddPersonCommand(returnValidEmptyInput, 1, events::post, modelManagerSpy));
+        final AddPersonCommand apc = spy(new AddPersonCommand(0, returnValidEmptyInput, 1, events::post, modelManagerSpy));
         final Supplier<Optional<ReadOnlyPerson>> editInputWrapper = inputRetrieverWrapper(TestUtil.generateSamplePersonWithAllData(1));
 
         doNothing().when(apc).beforeGracePeriod(); // don't wipe interrupt code injection when grace period starts
@@ -160,7 +160,7 @@ public class AddPersonCommandTest {
     @Test
     public void interruptGracePeriod_withDeleteRequest_cancelsCommand() {
         // grace period duration must be non zero, will be interrupted immediately anyway
-        final AddPersonCommand apc = spy(new AddPersonCommand(returnValidEmptyInput, 1, null, modelManagerSpy));
+        final AddPersonCommand apc = spy(new AddPersonCommand(0, returnValidEmptyInput, 1, null, modelManagerSpy));
 
         doNothing().when(apc).beforeGracePeriod(); // don't wipe interrupt code injection when grace period starts
         apc.deleteInGracePeriod(); // pre-specify apc will be interrupted by delete
@@ -175,7 +175,7 @@ public class AddPersonCommandTest {
     @Test
     public void interruptGracePeriod_withCancelRequest_undoesSimulation() {
         // grace period duration must be non zero, will be interrupted immediately anyway
-        final AddPersonCommand apc = spy(new AddPersonCommand(returnValidEmptyInput, 1, null, modelManagerSpy));
+        final AddPersonCommand apc = spy(new AddPersonCommand(0, returnValidEmptyInput, 1, null, modelManagerSpy));
 
         doNothing().when(apc).beforeGracePeriod(); // don't wipe interrupt code injection when grace period starts
         apc.cancelInGracePeriod(); // pre-specify apc will be interrupted by cancel

--- a/src/test/java/address/model/DeletePersonCommandTest.java
+++ b/src/test/java/address/model/DeletePersonCommandTest.java
@@ -73,7 +73,7 @@ public class DeletePersonCommandTest {
         doThrow(InterruptAndTerminateException.class).when(otherCommand).waitForCompletion(); // don't actually wait
         thrown.expect(InterruptAndTerminateException.class);
 
-        (new DeletePersonCommand(testTarget, 0, null, modelManagerSpy)).run();
+        (new DeletePersonCommand(0, testTarget, 0, null, modelManagerSpy)).run();
 
         verify(otherCommand).waitForCompletion();
         verify(modelManagerSpy, never()).assignOngoingChangeToPerson(any(), any());
@@ -81,13 +81,13 @@ public class DeletePersonCommandTest {
 
     @Test
     public void getTargetPersonId_returnsCorrectId() {
-        final DeletePersonCommand epc = new DeletePersonCommand(testTarget, 0, null, modelManagerMock);
+        final DeletePersonCommand epc = new DeletePersonCommand(0, testTarget, 0, null, modelManagerMock);
         assertEquals(epc.getTargetPersonId(), TEST_ID);
     }
 
     @Test
     public void optimisticUiUpdate_flagsDelete() {
-        final DeletePersonCommand dpc = spy(new DeletePersonCommand(testTarget, 0, events::post, modelManagerSpy));
+        final DeletePersonCommand dpc = spy(new DeletePersonCommand(0, testTarget, 0, events::post, modelManagerSpy));
 
         // to stop the run at start of grace period (right after simulated change)
         doThrow(new InterruptAndTerminateException()).when(dpc).beforeGracePeriod();
@@ -99,7 +99,7 @@ public class DeletePersonCommandTest {
 
     @Test
     public void succesfulDelete_updatesBackingModelCorrectly() {
-        final DeletePersonCommand dpc = new DeletePersonCommand(testTarget, 0, events::post, modelManagerSpy);
+        final DeletePersonCommand dpc = new DeletePersonCommand(0, testTarget, 0, events::post, modelManagerSpy);
 
         modelManagerSpy.visibleModel().addPerson(testTarget);
         modelManagerSpy.addPersonToBackingModelSilently(testTarget.getBacking());
@@ -112,7 +112,7 @@ public class DeletePersonCommandTest {
     @Test
     public void interruptGracePeriod_withEditRequest_cancelsAndSpawnsEditCommand() {
         // grace period duration must be non zero, will be interrupted immediately anyway
-        final DeletePersonCommand dpc = spy(new DeletePersonCommand(testTarget, 1, null, modelManagerSpy));
+        final DeletePersonCommand dpc = spy(new DeletePersonCommand(0, testTarget, 1, null, modelManagerSpy));
         final Supplier<Optional<ReadOnlyPerson>> editInputRetriever = Optional::empty;
 
         doNothing().when(modelManagerSpy).execNewEditPersonCommand(any(), any());
@@ -128,7 +128,7 @@ public class DeletePersonCommandTest {
     @Test
     public void interruptGracePeriod_withCancelRequest_undoesSimulation() {
         // grace period duration must be non zero, will be interrupted immediately anyway
-        final DeletePersonCommand dpc = spy(new DeletePersonCommand(testTarget, 1, null, modelManagerSpy));
+        final DeletePersonCommand dpc = spy(new DeletePersonCommand(0, testTarget, 1, null, modelManagerSpy));
         final Supplier<Optional<ReadOnlyPerson>> editInputRetriever = Optional::empty;
 
         modelManagerSpy.visibleModel().addPerson(testTarget);

--- a/src/test/java/address/model/EditPersonCommandTest.java
+++ b/src/test/java/address/model/EditPersonCommandTest.java
@@ -81,7 +81,7 @@ public class EditPersonCommandTest {
         doThrow(InterruptAndTerminateException.class).when(otherCommand).waitForCompletion(); // don't actually wait
         thrown.expect(InterruptAndTerminateException.class);
 
-        (new EditPersonCommand(testTarget, returnValidEmptyInput, 0, null, modelManagerSpy)).run();
+        (new EditPersonCommand(0, testTarget, returnValidEmptyInput, 0, null, modelManagerSpy)).run();
 
         verify(otherCommand).waitForCompletion();
         verify(modelManagerSpy, never()).assignOngoingChangeToPerson(any(), any());
@@ -89,20 +89,20 @@ public class EditPersonCommandTest {
 
     @Test
     public void getTargetPersonId_returnsCorrectId() {
-        final EditPersonCommand epc = new EditPersonCommand(testTarget, null, 0, null, modelManagerMock);
+        final EditPersonCommand epc = new EditPersonCommand(0, testTarget, null, 0, null, modelManagerMock);
         assertEquals(epc.getTargetPersonId(), TEST_ID);
     }
 
     @Test
     public void retrievingInput_cancelsCommand_whenEmptyInputOptionalRetrieved() {
-        final EditPersonCommand epc = new EditPersonCommand(testTarget, Optional::empty, 0, null, modelManagerMock);
+        final EditPersonCommand epc = new EditPersonCommand(0, testTarget, Optional::empty, 0, null, modelManagerMock);
         epc.run();
         assertEquals(epc.getState(), State.CANCELLED);
     }
 
     @Test
     public void optimisticUiUpdate_simulatesCorrectData() {
-        final EditPersonCommand epc = spy(new EditPersonCommand(testTarget, inputRetrieverWrapper(inputData),
+        final EditPersonCommand epc = spy(new EditPersonCommand(0, testTarget, inputRetrieverWrapper(inputData),
                 0, null, modelManagerSpy));
 
         // to stop the run at start of grace period (right after simulated change)
@@ -119,7 +119,7 @@ public class EditPersonCommandTest {
 
     @Test
     public void succesfulEdit_updatesBackingModelCorrectly() {
-        final EditPersonCommand epc = new EditPersonCommand(testTarget, inputRetrieverWrapper(inputData),
+        final EditPersonCommand epc = new EditPersonCommand(0, testTarget, inputRetrieverWrapper(inputData),
                 0, events::post, modelManagerSpy);
         epc.run();
         assertTrue(epc.getViewable().dataFieldsEqual(inputData));
@@ -130,7 +130,7 @@ public class EditPersonCommandTest {
     @Test
     public void interruptGracePeriod_withEditRequest_changesEditResult() {
         // grace period duration must be non zero, will be interrupted immediately anyway
-        final EditPersonCommand epc = spy(new EditPersonCommand(testTarget, returnValidEmptyInput, 1, events::post, modelManagerSpy));
+        final EditPersonCommand epc = spy(new EditPersonCommand(0, testTarget, returnValidEmptyInput, 1, events::post, modelManagerSpy));
         final Supplier<Optional<ReadOnlyPerson>> editInputWrapper = inputRetrieverWrapper(inputData);
 
         doNothing().when(epc).beforeGracePeriod(); // don't wipe interrupt code injection when grace period starts
@@ -144,7 +144,7 @@ public class EditPersonCommandTest {
     @Test
     public void interruptGracePeriod_withDeleteRequest_cancelsAndSpawnsDeleteCommand() {
         // grace period duration must be non zero, will be interrupted immediately anyway
-        final EditPersonCommand epc = spy(new EditPersonCommand(testTarget, returnValidEmptyInput, 1, null, modelManagerSpy));
+        final EditPersonCommand epc = spy(new EditPersonCommand(0, testTarget, returnValidEmptyInput, 1, null, modelManagerSpy));
 
         doNothing().when(modelManagerSpy).execNewDeletePersonCommand(any());
         doNothing().when(epc).beforeGracePeriod(); // don't wipe interrupt code injection when grace period starts
@@ -160,7 +160,7 @@ public class EditPersonCommandTest {
     public void interruptGracePeriod_withCancelRequest_undoesSimulation() {
         final ReadOnlyPerson targetSnapshot = new Person(testTarget);
         // grace period duration must be non zero, will be interrupted immediately anyway
-        final EditPersonCommand epc = spy(new EditPersonCommand(testTarget, returnValidEmptyInput, 1, null, modelManagerSpy));
+        final EditPersonCommand epc = spy(new EditPersonCommand(0, testTarget, returnValidEmptyInput, 1, null, modelManagerSpy));
 
         doNothing().when(epc).beforeGracePeriod(); // don't wipe interrupt code injection when grace period starts
         epc.cancelInGracePeriod(); // pre-specify epc will be interrupted by cancel


### PR DESCRIPTION
Resolves #412 
Related: #413 

@yl-coder: calling `ModelManager.getFinishedCommands()` will return an unmodifiable observable list of `CommandInfo` elements which will be updated dynamically by model. Newly finished commands are appended to the end of the list